### PR TITLE
test: register stopping the child processes with atexit

### DIFF
--- a/testTop/pyTestsApp/GatewayControl.py
+++ b/testTop/pyTestsApp/GatewayControl.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 '''Controls the CA Gateway'''
 import subprocess
+import atexit
 import time
 import os
 import gwtests
@@ -24,10 +25,13 @@ class GatewayControl:
         if not gwtests.verboseGateway and not gwtests.verbose:
             self.DEVNULL = open(os.devnull, 'wb')
         self.gatewayProcess = subprocess.Popen(gateway_commands, stdout=self.DEVNULL, stderr=subprocess.STDOUT)
+        atexit.register(self.stop)
 
     def stop(self):
         '''Stops the CA Gateway'''
-        self.gatewayProcess.terminate()
+        if self.gatewayProcess:
+            self.gatewayProcess.terminate()
+            self.gatewayProcess = None
         if self.DEVNULL:
             self.DEVNULL.close()
 

--- a/testTop/pyTestsApp/IOCControl.py
+++ b/testTop/pyTestsApp/IOCControl.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 '''Controls the test IOC'''
-import os
 import subprocess
+import atexit
 import time
+import os
 import gwtests
 
 class IOCControl:
@@ -38,10 +39,13 @@ class IOCControl:
         self.iocProcess = subprocess.Popen(iocCommand, env=childEnviron,
                 stdin=subprocess.PIPE, stdout=self.DEVNULL, stderr=subprocess.STDOUT)
         time.sleep(.5)
+        atexit.register(self.stop)
 
     def stop(self):
         '''Stops the test IOC'''
-        self.iocProcess.stdin.close()
+        if self.iocProcess:
+            self.iocProcess.stdin.close()
+            self.iocProcess = None
         if self.DEVNULL:
             self.DEVNULL.close()
 


### PR DESCRIPTION
An attempt to improve the test clean-up by registering the `stop()` functions of both control classes (for the IOC and the Gateway) with `atexit`.

@anjohnson: please check if this fixes epics-extensions/ca-gateway#10 - the doc says `atexit` functions are only called on a regular Python exit, and I don't know if your failure case falls under that category.