### PR TITLE
Support for caPutLog >= R3.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ to needed process variables.
 The Gateway typically runs on a machine with multiple network cards,
 and the clients and the server may be on different subnets.
 
+## Dependencies
+
+The CA Gateway is using the PCAS server library and needs the PCAS module (https://github.com/epics-modules/pcas) that was unbundled from Base back in 3.16.
+
+If you use caPutLog (https://github.com/epics-modules/caPutLog), CA Gateway now requires it to be greater or equal R3.5.
+
 ## Continuous Integration
 
 The CI jobs for CA Gateway are provided by

--- a/configure/RELEASE
+++ b/configure/RELEASE
@@ -21,6 +21,10 @@
 
 #CAPUTLOG=/usr/lib/epics
 
+# PCAS was unbundled from EPICS Base and is needed for building the
+# ca-gateway with EPICS 7
+#PCAS=/your/path/to/modules/pcas/
+
 # EPICS_BASE usually appears last so other apps can override stuff:
 #EPICS_BASE=/usr/lib/epics
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -103,7 +103,7 @@ USR_INCLUDES += -I$(EPICS_BASE)/src/ca/legacy/pcas/generic
 # To compile in caPutLog functionality, define the location of the caPutLog
 # module as 'CAPUTLOG' in the appropriate extensions configure/RELEASE* file
 ifdef CAPUTLOG
-  USR_LIBS += caPutLog dbIoc
+  USR_LIBS += caPutLog $(EPICS_BASE_IOC_LIBS)
   USR_CXXFLAGS += -DWITH_CAPUTLOG
   USR_CFLAGS += -DWITH_CAPUTLOG
 endif

--- a/src/gatePv.cc
+++ b/src/gatePv.cc
@@ -1362,8 +1362,8 @@ void gatePvData::connectCB(CONNECT_ARGS args)
 #endif
 
 	// send message to user concerning connection
-			if(ca_state(args.chid)==cs_conn)
-{
+	if(ca_state(args.chid)==cs_conn)
+	{
 		gateDebug0(9,"gatePvData::connectCB() connection ok\n");
 
 		switch(ca_field_type(args.chid))
@@ -1509,7 +1509,7 @@ void gatePvData::putCB(EVENT_ARGS args)
 	pv->vc->putCB(args.status,*pWIO);
 }
 
-// This is the callback registered with ca_add_subscription in the
+// This is the callback registered with ca_create_subscription in the
 // monitor routine.  If conditions are right, it calls the routines
 // that copy the data into the GateVcData's event_data.
 void gatePvData::eventCB(EVENT_ARGS args)

--- a/src/gateResources.cc
+++ b/src/gateResources.cc
@@ -159,42 +159,42 @@ static int gddToVALUE(const gdd *gddVal, short ourdbrtype, VALUE *valueStruct)
     case OUR_DBR_CHAR: {
           aitInt8 x;
           gddVal->get(x);
-          valueStruct->v_char = x;
+          valueStruct->v_int8 = x;
         }
         return(0);
 
     case OUR_DBR_UCHAR: {
           aitUint8 x;
           gddVal->get(x);
-          valueStruct->v_uchar = x;
+          valueStruct->v_uint8 = x;
         }
         return(0);
 
     case OUR_DBR_SHORT: {
           aitInt16 x;
           gddVal->get(x);
-          valueStruct->v_short = x;
+          valueStruct->v_int16 = x;
         }
         return(0);
 
     case OUR_DBR_USHORT: {
           aitUint16 x;
           gddVal->get(x);
-          valueStruct->v_ushort = x;
+          valueStruct->v_uint16 = x;
         }
         return(0);
 
     case OUR_DBR_LONG: {
           aitInt32 x;
           gddVal->get(x);
-          valueStruct->v_long = x;
+          valueStruct->v_int32 = x;
         }
         return(0);
 
     case OUR_DBR_ULONG: {
           aitUint32 x;
           gddVal->get(x);
-          valueStruct->v_ulong = x;
+          valueStruct->v_uint32 = x;
         }
         return(0);
 
@@ -229,26 +229,27 @@ static int gddToVALUE(const gdd *gddVal, short ourdbrtype, VALUE *valueStruct)
   }
 }
 
+#if 0
 static char *debugVALUEString(VALUE *v, int ourdbrtype, char *buffer)
 {
   switch (ourdbrtype) {
     case OUR_DBR_CHAR:
-      sprintf(buffer,"v_char %d",v->v_char);
+      sprintf(buffer,"v_int8 %d",v->v_int8);
       break;
     case OUR_DBR_UCHAR:
-      sprintf(buffer,"v_uchar %d",v->v_uchar);
+      sprintf(buffer,"v_uint8 %d",v->v_uint8);
       break;
     case OUR_DBR_SHORT:
-      sprintf(buffer,"v_short %hd",v->v_short);
+      sprintf(buffer,"v_int16 %hd",v->v_int16);
       break;
     case OUR_DBR_USHORT:
-      sprintf(buffer,"v_ushort %hu",v->v_ushort);
+      sprintf(buffer,"v_uint16 %hu",v->v_uint16);
       break;
     case OUR_DBR_LONG:
-      sprintf(buffer,"v_long %ld",v->v_long);
+      sprintf(buffer,"v_int32 %d",v->v_int32);
       break;
     case OUR_DBR_ULONG:
-      sprintf(buffer,"v_ulong %lu",v->v_ulong);
+      sprintf(buffer,"v_uint32 %u",v->v_uint32);
       break;
     case OUR_DBR_FLOAT:
       sprintf(buffer,"v_float %g",v->v_float);
@@ -264,6 +265,7 @@ static char *debugVALUEString(VALUE *v, int ourdbrtype, char *buffer)
   }
   return(buffer);
 }
+#endif
 
 #endif // WITH_CAPUTLOG
 

--- a/src/gateResources.cc
+++ b/src/gateResources.cc
@@ -198,6 +198,24 @@ static int gddToVALUE(const gdd *gddVal, short ourdbrtype, VALUE *valueStruct)
         }
         return(0);
 
+#ifdef DBR_INT64
+    case OUR_DBR_INT64: {
+          aitInt64 x;
+          gddVal->get(x);
+          valueStruct->v_int64 = x;
+        }
+        return(0);
+#endif
+
+#ifdef DBR_UINT64
+    case OUR_DBR_UINT64: {
+          aitUint64 x;
+          gddVal->get(x);
+          valueStruct->v_uint64 = x;
+        }
+        return(0);
+#endif
+
     case OUR_DBR_FLOAT: {
           aitFloat32 x;
           gddVal->get(x);

--- a/src/gateResources.cc
+++ b/src/gateResources.cc
@@ -427,6 +427,41 @@ void gateResources::caPutLog_Send
   }
   caPutLogTaskSend(pdata);
 }
+
+void gateResources::putLog(
+       FILE            *       fp,
+       const char      *       user,
+       const char      *       host,
+       const char      *       pvname,
+       const gdd       *       old_value,
+       const gdd       *       new_value       )
+{
+       if(fp) {
+               VALUE   oldVal,                 newVal;
+               char    acOldVal[20],   acNewVal[20];
+               if ( old_value == NULL )
+               {
+                       acOldVal[0] = '?';
+                       acOldVal[1] = '\0';
+               }
+               else
+               {
+                       gddToVALUE( old_value, gddGetOurType(old_value), &oldVal );
+                       VALUE_to_string( acOldVal, 20, &oldVal, gddGetOurType(old_value) );
+               }
+               gddToVALUE( new_value, gddGetOurType(new_value), &newVal );
+               VALUE_to_string( acNewVal, 20, &newVal, gddGetOurType(new_value) );
+               fprintf(fp,"%s %s@%s %s %s old=%s\n",
+                 timeStamp(),
+                 user?user:"Unknown",
+                 host?host:"Unknown",
+                 pvname,
+                 acNewVal,
+                 acOldVal );
+               fflush(fp);
+       }
+}
+
 #endif // WITH_CAPUTLOG
 
 int gateResources::setReportFile(const char* file)

--- a/src/gateResources.h
+++ b/src/gateResources.h
@@ -145,6 +145,12 @@ public:
                        const gdd *old_value,
                        const gdd *new_value);
 	void caPutLog_Term(void);
+    void putLog(	   FILE *fp,
+    				   const char *user,
+                       const char *host,
+                       const char *pvname,
+                       const gdd *old_value,
+                       const gdd *new_value);
 #endif
 
 	// here for convenience

--- a/src/gateway.cc
+++ b/src/gateway.cc
@@ -374,6 +374,7 @@ static int startEverything(char *prefix)
 		if(tempBuff != NULL){
 			if(strcasecmp(tempBuff,"NO")){
                 setEnv("EPICS_CAS_AUTO_BEACON_ADDR_LIST","YES",&gate_beacon_ca_auto_list);
+				gateDebug1(15,"gateway setting <%s>\n",gate_beacon_ca_auto_list);
 			}
 		}
 		gateDebug1(15,"gateway setting <%s>\n",gate_ca_auto_list);
@@ -600,6 +601,7 @@ static int startEverything(char *prefix)
 #else
 	printf("%s PID=%d\n",EPICS_VERSION_STRING,sid);
 #endif
+	printf("CA Protocol version %s\n", ca_version());
 	printEnv(stdout,"EPICS_CA_ADDR_LIST");
 	printEnv(stdout,"EPICS_CA_AUTO_ADDR_LIST");
 	printEnv(stdout,"EPICS_CA_SERVER_PORT");
@@ -607,6 +609,8 @@ static int startEverything(char *prefix)
 	printEnv(stdout,"EPICS_CAS_INTF_ADDR_LIST");
 	printEnv(stdout,"EPICS_CAS_SERVER_PORT");
 	printEnv(stdout,"EPICS_CAS_IGNORE_ADDR_LIST");
+	printEnv(stdout,"EPICS_CAS_AUTO_BEACON_ADDR_LIST");
+	printEnv(stdout,"EPICS_CAS_BEACON_ADDR_LIST");
 
 	// Get user name
 	char userName[21];


### PR DESCRIPTION
This patch was originally made by @bhill-slac .

@bfrk changed the caPutLog and renamed the members of the VALUE union (See: https://github.com/epics-modules/caPutLog/commit/1fbe2ed1f7fe26ed9edc98fada7f96ecf033ab64)
This means that the ca-gateway will not build with versions of caPutLog greater than R3-4.

This Pull Request also adds the note at the README file that EPICS 7 needs PCAS as an external module to be added to the RELEASE file.