### PR TITLE
Proposed fix for #20

### DIFF
--- a/src/gatePv.cc
+++ b/src/gatePv.cc
@@ -1830,14 +1830,14 @@ void gatePvData::getCB(EVENT_ARGS args)
                 dd = pv->runValueDataCB(&args);
                 if (dd)
                     pv->vc->setEventData(dd);
-            }
 
-            if (pv->needAddRemove() && !pv->vc->needPosting()) {
-                gateDebug0(5,"gatePvData::getCB() need add/remove\n");
-                pv->markAddRemoveNotNeeded();
-                pv->vc->vcAdd(read_type);
-            } else
-                pv->vc->vcData(read_type);
+                if (pv->needAddRemove() && !pv->vc->needPosting()) {
+                    gateDebug0(5, "gatePvData::getCB() need add/remove\n");
+                    pv->markAddRemoveNotNeeded();
+                    pv->vc->vcAdd(read_type);
+                } else
+                    pv->vc->vcData(read_type);
+            }
 
             if (pv->vc->needPosting()) {  // enable monitor only if requested
                 gateDebug0(5,"gatePvData::getCB() [NO_CACHE] Enable value monitor\n");

--- a/testTop/pyTestsApp/GatewayControl.py
+++ b/testTop/pyTestsApp/GatewayControl.py
@@ -10,13 +10,21 @@ class GatewayControl:
     gatewayProcess = None
     DEVNULL = None
 
-    def startGateway(self):
-        '''Starts the CA Gateway'''
+    def startGateway(self, extra_args=None):
+        '''
+        Starts the CA Gateway
+
+        Params:
+            extra_args (str): Extra arguments passed to the gateway process
+        '''
         gateway_commands = [gwtests.gwExecutable]
         gateway_commands.extend(["-sip", "localhost", "-sport", str(gwtests.gwPort)])
         gateway_commands.extend(["-cip", "localhost", "-cport", str(gwtests.iocPort)])
         gateway_commands.extend(["-access", "access.txt", "-pvlist", "pvlist.txt"])
         gateway_commands.extend(["-archive", "-prefix", gwtests.gwStatsPrefix])
+        # Append extra arguments
+        if extra_args is not None:
+            gateway_commands.extend(extra_args.split(" "))
 
         if gwtests.verboseGateway:
             gateway_commands.extend(["-debug", str(gwtests.gwDebug)]);
@@ -35,6 +43,9 @@ class GatewayControl:
         if self.DEVNULL:
             self.DEVNULL.close()
 
+    def poll(self):
+        return self.gatewayProcess.poll()
+
 
 if __name__ == "__main__":
     gwtests.setup()
@@ -42,6 +53,6 @@ if __name__ == "__main__":
     gwtests.verbose = True
     gwtests.verboseGateway = True
     gatewayControl = GatewayControl()
-    gatewayControl.startGateway()
+    gatewayControl.startGateway(extra_args="-no_cache")
     time.sleep(gwtests.gwRunDuration)
     gatewayControl.stop()

--- a/testTop/pyTestsApp/TestWaveformWithCAMaxArrayBytes.py
+++ b/testTop/pyTestsApp/TestWaveformWithCAMaxArrayBytes.py
@@ -75,7 +75,6 @@ class TestWaveformWithCAMaxArrayBytes(unittest.TestCase):
                 waveform_from_gateway = w
                 print(waveform_from_gateway)
                 print "waveform_from_gateway"
-                self.assertEqual(list(waveform_from_gateway), [0]*3000)
             finally:
                 self.gatewayControl.stop()
                 self.iocControl.stop()

--- a/testTop/pyTestsApp/TestWaveformWithCAMaxArrayBytes.py
+++ b/testTop/pyTestsApp/TestWaveformWithCAMaxArrayBytes.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python
+import os
+import unittest
+from epics import caget, caput, PV
+import IOCControl
+import GatewayControl
+import gwtests
+
+
+max_array_bytes_key = "IOC_EPICS_CA_MAX_ARRAY_BYTES"
+
+class TestWaveformWithCAMaxArrayBytes(unittest.TestCase):
+    '''
+    Tests for a bug where the gateway will segfault when a waveform is
+    requested through the gateway and the value of
+    EPICS_CA_MAX_ARRAY_BYTES in the IOC is too small.
+
+    Reference https://github.com/epics-extensions/ca-gateway/issues/20
+    '''
+
+    def test_gateway_does_not_crash_after_requesting_waveform_when_max_array_bytes_too_small(self):
+
+
+        gwtests.setup()
+        self.iocControl = IOCControl.IOCControl()
+        self.gatewayControl = GatewayControl.GatewayControl()
+
+        # If the bug is present this test is designed to pass the first case
+        # and fail the second case
+        max_array_bytes_cases = ["6000000", "16384"]
+        for max_array_bytes in max_array_bytes_cases:
+            print("\n\n\n>>>>>IOC_EPICS_MAX_ARRAY_BYTES={}\n\n\n"
+                  .format(max_array_bytes))
+
+            # The bug crashes the gateway when EPICS_CA_MAX_ARRAY_BYTES
+            # on the IOC is too small. Set it here
+            os.environ["IOC_EPICS_CA_MAX_ARRAY_BYTES"] = max_array_bytes
+            self.iocControl.startIOC()
+
+            # The no_cache argument is required to trigger the bug
+            self.gatewayControl.startGateway(extra_args="-no_cache")
+            os.environ["EPICS_CA_AUTO_ADDR_LIST"] = "NO"
+            os.environ["EPICS_CA_ADDR_LIST"] = (
+                "localhost:{0} localhost:{1}".format(
+                gwtests.iocPort, gwtests.gwPort)
+            )
+
+            # First check that a simple PV can be put and got through gateway
+            put_value = 5
+            caput("gateway:passive0", put_value, wait=True)
+            result = caget("gateway:passive0")
+
+            self.assertIsNotNone(result)
+            self.assertEqual(
+                result, put_value,
+                msg="Initial get: got {} expected {}".format(
+                    result, put_value
+                )
+            )
+
+            # Then try to get waveform through gateway
+            try:
+                w = PV("gateway:bigpassivewaveform").get(
+                    count=3000,
+                    # CTRL type is required to trigger the bug
+                    with_ctrlvars=True
+                )
+                self.gatewayControl.poll()
+            except TypeError as e:
+                raise RuntimeError("Gateway has crashed - "
+                                   "exception from pyepics: %s", e)
+            except OSError as e:
+                raise RuntimeError("Gateway has crashed - "
+                                   "exception from subprocess: %s", e)
+            else:
+                waveform_from_gateway = w
+
+                print(waveform_from_gateway)
+                print "waveform_from_gateway"
+                self.assertEqual(list(waveform_from_gateway), [0]*3000)
+            finally:
+                self.gatewayControl.stop()
+                self.iocControl.stop()
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/testTop/pyTestsApp/TestWaveformWithCAMaxArrayBytes.py
+++ b/testTop/pyTestsApp/TestWaveformWithCAMaxArrayBytes.py
@@ -7,7 +7,8 @@ import GatewayControl
 import gwtests
 
 
-max_array_bytes_key = "IOC_EPICS_CA_MAX_ARRAY_BYTES"
+MAX_ARRAY_BYTES_KEY = "IOC_EPICS_CA_MAX_ARRAY_BYTES"
+
 
 class TestWaveformWithCAMaxArrayBytes(unittest.TestCase):
     '''
@@ -19,8 +20,6 @@ class TestWaveformWithCAMaxArrayBytes(unittest.TestCase):
     '''
 
     def test_gateway_does_not_crash_after_requesting_waveform_when_max_array_bytes_too_small(self):
-
-
         gwtests.setup()
         self.iocControl = IOCControl.IOCControl()
         self.gatewayControl = GatewayControl.GatewayControl()
@@ -29,12 +28,12 @@ class TestWaveformWithCAMaxArrayBytes(unittest.TestCase):
         # and fail the second case
         max_array_bytes_cases = ["6000000", "16384"]
         for max_array_bytes in max_array_bytes_cases:
-            print("\n\n\n>>>>>IOC_EPICS_MAX_ARRAY_BYTES={}\n\n\n"
-                  .format(max_array_bytes))
+            print("\n\n\n>>>>>{}={}\n\n\n"
+                  .format(MAX_ARRAY_BYTES_KEY, max_array_bytes))
 
             # The bug crashes the gateway when EPICS_CA_MAX_ARRAY_BYTES
             # on the IOC is too small. Set it here
-            os.environ["IOC_EPICS_CA_MAX_ARRAY_BYTES"] = max_array_bytes
+            os.environ[MAX_ARRAY_BYTES_KEY] = max_array_bytes
             self.iocControl.startIOC()
 
             # The no_cache argument is required to trigger the bug
@@ -74,13 +73,13 @@ class TestWaveformWithCAMaxArrayBytes(unittest.TestCase):
                                    "exception from subprocess: %s", e)
             else:
                 waveform_from_gateway = w
-
                 print(waveform_from_gateway)
                 print "waveform_from_gateway"
                 self.assertEqual(list(waveform_from_gateway), [0]*3000)
             finally:
                 self.gatewayControl.stop()
                 self.iocControl.stop()
+
 
 if __name__ == '__main__':
     unittest.main(verbosity=2)

--- a/testTop/pyTestsApp/test.db
+++ b/testTop/pyTestsApp/test.db
@@ -60,6 +60,13 @@ record(waveform, "ioc:passivewaveform") {
   field(FTVL, "DOUBLE")
 }
 
+record(waveform, "ioc:bigpassivewaveform") {
+  field(DESC, "Big passive waveform")
+  field(SCAN, "Passive")
+  field(NELM, "3000")
+  field(FTVL, "DOUBLE")
+}
+
 record(ai, "ioc:gwcachetest") {
   field(PREC, "3")
   field(EGU, "wobbles")


### PR DESCRIPTION
I have a proposed fix for #20.

Here is a summary of the motivation.

First I tried to track down what was happening at the moment of the segmentation fault.
It appears from the stack trace in GDB that it was in the channel access server code, doing a memcpy to convert the data to pass back to the client.
```
(gdb) bt 
#0 0x00007f00bf1e86f0 in __memcpy_ssse3_back () from /lib64/libc.so.6 
#1 0x00007f00c0788fbd in aitConvertEnum16Enum16 (d=<optimized out>, s=<optimized out>, c=1) at ../O.Common/aitConvertGenerated.cc:2455 
#2 0x00007f00c09c7a20 in casStrmClient::readNotifyResponse (this=0x13120f0, guard=..., pChan=0x13123d0, msg=..., desc=..., completionStatus=<optimized out>) at ../../../../src/cas/generic/casStrmClient.cc:709 
#3 0x00007f00c09cc4fd in casAsyncReadIOI::cbFuncAsyncIO (this=0x1311940, guard=...) at ../../../../src/cas/generic/casAsyncReadIOI.cc:67 
#4 0x00007f00c09cc0f1 in casAsyncIOI::cbFunc (this=0x1311940, clientGuard=...) at ../../../../src/cas/generic/casAsyncIOI.cc:86 
#5 0x00007f00c09cd941 in casEventSys::process (this=this@entry=0x1312118, casClientGuard=...) at ../../../../src/cas/generic/casEventSys.cc:102 
#6 0x00007f00c09d2cfe in eventSysProcess (this=0x13120f0) at ../../../../src/cas/generic/casCoreClient.h:176 
#7 casStreamEvWakeup::expire (this=0x1312338) at ../../../../src/cas/generic/st/casStreamOS.cc:150 
#8 0x00007f00bfcbeb7e in timerQueue::process (this=0x12cf748, currentTime=...) at ../../../src/libCom/timer/timerQueue.cpp:139 
#9 0x00007f00bfca69d8 in fdManager::process (this=0x62cdc0 <fileDescriptorManager>, delay=delay@entry=0.01) at ../../../src/libCom/fdmgr/fdManager.cpp:103 
#10 0x0000000000414c2e in gateServer::mainLoop (this=this@entry=0x12ceb70) at ../gateServer.cc:280 
#11 0x0000000000407779 in startEverything (prefix=0x7fff844f5ab3 "gwtest") at ../gateway.cc:686 
#12 main (argc=19, argv=<optimized out>) at ../gateway.cc:1354
```
I added printfs in the base code; the routine `aitConvertEnum16Enum16` is triggered by a function `mapGddToEnum` in `<base>/src/gdd/dbMapper.cc`. I compared the cases of `EPICS_CA_MAX_ARRAY_BYTES` in the server large enough and too small, when requesting a waveform with `FTVL` double with CTRL type. It appears that in the good case, zero elements are requested for conversion (which I believe means the whole array), whereas in the bad case one element is requested. I assume this enum conversion process is something to do with the control variables which is why it is not seen when not requesting CTRL type.

I also looked in detail at the code in `gatePv.cc`. I focused my attention in `getCB`, the function that is registered as the callback for the initial get. It receives the status code from the get as one of the arguments. It looks like in the bad case, the return code is 72, which is the code for `EPICS_CA_MAX_ARRAY_BYTES` too small: https://epics.anl.gov/docs/CAproto.html

I therefore came to believe that in this case, when the get failed, we have bad data in memory and we are wrongly asking the channel access server code to send this back to the client.

Having identified the commit c6dc159 as the one where the problem first appeared, I looked at the changes to getCB in this commit. It looks to me like the calls to `vcData` and `vcAdd` were previously not executed when the status code of the get was not ECA_NORMAL, but after this commit they are (in no_cache mode). These are the calls in question, which as I understand cause the received data to be sent to the client:
```
                if (pv->needAddRemove() && !pv->vc->needPosting()) {
                    gateDebug0(5, "gatePvData::getCB() need add/remove\n");
                    pv->markAddRemoveNotNeeded();
                    pv->vc->vcAdd(read_type);
                } else
                    pv->vc->vcData(read_type);
```
I also noted that these are not called when we are in cache mode. Further, in eventCB, the callback function for events coming in from a monitor (which is triggered eventually in both cache and no_cache mode), these lines appear but are protected by a check `if args.status == ECA_NORMAL`.

My change was in the `no_cache` branch of `getCB`, to move these lines inside the  `if args.status == ECA_NORMAL`. The idea is to prevent bad data from being copied and sent back if the initial get was not successful.

As far as I have been able to test this appears to fix the problem. I've added a test case to the testing framework which demonstrates it.

It would be great to get feedback on my reasoning and whether or not this is a good solution.