### PR TITLE
Ip ignore as ipag

### DIFF
--- a/src/gateAs.cc
+++ b/src/gateAs.cc
@@ -253,14 +253,22 @@ gateAsClient::gateAsClient(void) :
 }
 
 gateAsClient::gateAsClient(gateAsEntry *pEntry, const char *user,
-  const char *host) :
+  const char *host
+#ifdef EPICS_HAS_AS_IPAG
+  ,epicsUInt32 ip_addr
+#endif
+  ) :
 	asclientpvt(NULL),
 	asentry(pEntry),
 	user_arg(NULL),
 	user_func(NULL)
 {
-	if(pEntry&&asAddClient(&asclientpvt,pEntry->asmemberpvt,pEntry->level,
-		 (char*)user,(char*)host) == 0) {
+	if(pEntry && asAddClient(&asclientpvt,pEntry->asmemberpvt,pEntry->level,
+		                 (char*)user ,(char*)host
+#ifdef EPICS_HAS_AS_IPAG
+                                 ,ip_addr
+#endif
+                                ) == 0) {
 		asPutClientPvt(asclientpvt,this);
 	}
 

--- a/src/gateAs.h
+++ b/src/gateAs.h
@@ -30,6 +30,8 @@
 #include <string.h>
 #include <stdlib.h>
 
+#include <epicsVersion.h>
+
 
 extern "C" {
 #include <ellLib.h>
@@ -152,7 +154,11 @@ class gateAsClient
 {
 public:
 	gateAsClient(void);
-	gateAsClient(gateAsEntry *pase, const char *user, const char *host);
+	gateAsClient(gateAsEntry *pase, const char *user, const char *host
+#ifdef EPICS_HAS_AS_IPAG
+                     ,epicsUInt32 ip_addr
+#endif
+                    );
 	~gateAsClient(void);
 
 	aitBool readAccess(void)  const
@@ -167,8 +173,17 @@ public:
     // Used in virtual function setOwner from casChannel, not called
     // from Gateway.  It is a security hole to support this, and it is
     // no longer implemented in base.
-	long changeInfo(const char* user, const char* host)
-	  { return asChangeClient(asclientpvt,asentry->level,(char*)user,(char*)host);}
+	long changeInfo(const char* user, const char* host
+#ifdef EPICS_HAS_AS_IPAG
+                        ,epicsUInt32 ip_addr
+#endif
+                       )
+	  { return asChangeClient(asclientpvt,asentry->level, (char*)user ,
+                                  (char*)host
+#ifdef EPICS_HAS_AS_IPAG
+                                  ,ip_addr
+#endif
+                                  );}
 #endif
 
 	const char *user(void) { return (const char*)asclientpvt->user; }

--- a/src/gateStat.cc
+++ b/src/gateStat.cc
@@ -30,6 +30,8 @@
 #include <time.h>
 #endif
 
+#include <epicsVersion.h>
+
 #include <gdd.h>
 #include <gddApps.h>
 #include "gateResources.h"
@@ -59,8 +61,16 @@ static struct timespec *timeSpec(void)
 //////// gateStatChan (derived from gate chan derived from casChannel)
 
 gateStatChan::gateStatChan(const casCtx &ctx, casPV *casPvIn, gateAsEntry *asentry,
-  const char * const user, const char * const host) :
-	gateChan(ctx,casPvIn,asentry,user,host)
+  const char * const user, const char * const host
+#ifdef EPICS_HAS_AS_IPAG
+  ,epicsUInt32 ip_addr
+#endif
+  ) :
+	gateChan(ctx,casPvIn,asentry,user,host
+#ifdef EPICS_HAS_AS_IPAG
+                 ,ip_addr
+#endif
+                )
 {
 	gateStat *pStat=(gateStat *)casPv;
 	if(pStat) pStat->addChan(this);
@@ -217,9 +227,17 @@ const char *gateStat::getName() const
 }
 
 casChannel* gateStat::createChannel(const casCtx &ctx,
-  const char * const user, const char * const host)
+  const char * const user, const char * const host
+#ifdef EPICS_HAS_AS_IPAG
+  ,epicsUInt32 ip_addr
+#endif
+  )
 {
-	gateStatChan *pChan=new gateStatChan(ctx,this,asentry,user,host);
+	gateStatChan *pChan=new gateStatChan(ctx,this,asentry,user,host
+#ifdef EPICS_HAS_AS_IPAG
+                                             ,ip_addr
+#endif
+                                            );
 	return pChan;
 }
 

--- a/src/gateStat.h
+++ b/src/gateStat.h
@@ -18,6 +18,8 @@
 #ifndef GATE_STAT_H
 #define GATE_STAT_H
 
+#include <epicsVersion.h>
+
 #include "casdef.h"
 #include "aitTypes.h"
 
@@ -38,7 +40,11 @@ class gateStatChan : public gateChan, public tsDLNode<gateStatChan>
 {
 public:
 	gateStatChan(const casCtx &ctx, casPV *pvIn, gateAsEntry *asentryIn,
-	  const char * const user, const char * const host);
+	  const char * const user, const char * const host
+#ifdef EPICS_HAS_AS_IPAG
+          ,epicsUInt32 ip_addr
+#endif
+          );
 	~gateStatChan(void);
 
 	virtual caStatus write(const casCtx &ctx, const gdd &value);
@@ -61,7 +67,11 @@ public:
 	virtual unsigned maxSimultAsyncOps(void) const;
 	virtual const char *getName() const;
 	virtual casChannel *createChannel (const casCtx &ctx,
-		const char* const pUserName, const char* const pHostName);
+		const char* const pUserName, const char* const pHostName
+#ifdef EPICS_HAS_AS_IPAG
+                ,epicsUInt32 ip_addr
+#endif
+                );
 
 	caStatus write(const casCtx &ctx, const gdd &dd, gateChan &chan);
 

--- a/src/gateVc.h
+++ b/src/gateVc.h
@@ -34,6 +34,8 @@
 # include <sys/time.h>
 #endif
 
+#include <epicsVersion.h>
+
 #include <caProto.h>
 
 #include "casdef.h"
@@ -74,14 +76,22 @@ class gateChan : public casChannel
 {
 public:
 	gateChan(const casCtx &ctx, casPV *pvIn, gateAsEntry *asentryIn,
-	  const char * const user, const char * const host);
+	  const char * const user, const char * const host
+#ifdef EPICS_HAS_AS_IPAG
+          ,epicsUInt32 ip_addr
+#endif
+          );
 	~gateChan(void);
 
 #ifdef SUPPORT_OWNER_CHANGE
     // Virtual function from casChannel, not called from Gateway.  It
     // is a security hole to support this, and it is no longer
     // implemented in base.
-	virtual void setOwner(const char * const user, const char * const host);
+	virtual void setOwner(const char * const user, const char * const host
+#ifdef EPICS_HAS_AS_IPAG
+                              ,epicsUInt32 ip_addr
+#endif
+                             );
 #endif
 
 	void report(FILE *fp);
@@ -103,13 +113,20 @@ protected:
 	gateAsClient *asclient; // Must be deleted when done using it
 	const char *user;
 	const char *host;
+#ifdef EPICS_HAS_AS_IPAG
+        epicsUInt32 ip_addr;
+#endif
 };
 
 class gateVcChan : public gateChan, public tsDLNode<gateVcChan>
 {
 public:
 	gateVcChan(const casCtx &ctx, casPV *pvIn, gateAsEntry *asentryIn,
-	  const char * const user, const char * const host);
+	  const char * const user, const char * const host
+#ifdef EPICS_HAS_AS_IPAG
+          ,epicsUInt32 ip_addr
+#endif
+          );
 	~gateVcChan(void);
 
     virtual caStatus write(const casCtx &ctx, const gdd &value);
@@ -138,7 +155,11 @@ public:
 	virtual unsigned maxDimension(void) const;
 	virtual aitIndex maxBound(unsigned dim) const;
 	virtual casChannel *createChannel (const casCtx &ctx,
-		const char* const pUserName, const char* const pHostName);
+		const char* const pUserName, const char* const pHostName
+#ifdef EPICS_HAS_AS_IPAG
+                ,epicsUInt32 ip_addr
+#endif
+                );
 	virtual const char *getName() const;
 
 	caStatus write(const casCtx &ctx, const gdd &value, gateChan &chan);

--- a/src/gateway.cc
+++ b/src/gateway.cc
@@ -591,6 +591,9 @@ static int startEverything(char *prefix)
 	printf("CA Protocol version %s\n", ca_version());
 	printEnv(stdout,"EPICS_CA_ADDR_LIST");
 	printEnv(stdout,"EPICS_CA_AUTO_ADDR_LIST");
+#ifdef EPICS_HAS_CA_IGNORE_NET_LIST
+	printEnv(stdout,"EPICS_CA_IGNORE_NET_LIST");
+#endif
 	printEnv(stdout,"EPICS_CA_SERVER_PORT");
 	printEnv(stdout,"EPICS_CA_MAX_ARRAY_BYTES");
 	printEnv(stdout,"EPICS_CAS_INTF_ADDR_LIST");

--- a/src/gateway.cc
+++ b/src/gateway.cc
@@ -596,6 +596,9 @@ static int startEverything(char *prefix)
 	printEnv(stdout,"EPICS_CAS_INTF_ADDR_LIST");
 	printEnv(stdout,"EPICS_CAS_SERVER_PORT");
 	printEnv(stdout,"EPICS_CAS_IGNORE_ADDR_LIST");
+#ifdef EPICS_HAS_CAS_IGNORE_NET_LIST
+	printEnv(stdout,"EPICS_CAS_IGNORE_NET_LIST");
+#endif
 	printEnv(stdout,"EPICS_CAS_AUTO_BEACON_ADDR_LIST");
 	printEnv(stdout,"EPICS_CAS_BEACON_ADDR_LIST");
 


### PR DESCRIPTION
Support for these 3 changes in EPICS Base and PCAS (if base 7.0 is used):

- Define networks to be ignored by servers with environment variable
  EPICS_CAS_IGNORE_NET_LIST
- Define networks to be ignored by clients with environment variable
  EPICS_CA_IGNORE_NET_LIST
- Extend channel access security with IP access groups that define the IP
  address a client must have
