### PR TITLE
Add Windows API version check for Mingw

### DIFF
--- a/src/gateServer.cc
+++ b/src/gateServer.cc
@@ -46,6 +46,11 @@
 #undef USE_LINUX_PROC_FOR_CPU
 #endif
 
+#if defined(__MINGW32__) || defined(__MINGW64__)
+  #define WINVER 0x0501
+  #define _WIN32_WINNT 0x0601
+#endif
+
 #ifdef _WIN32
   #ifdef _WIN64
     #define NO_OF_CPUS GetMaximumProcessorCount(ALL_PROCESSOR_GROUPS)


### PR DESCRIPTION
Without the version specified the Windows includes do not resolve some of the used constants when building with Mingw:

```../gateServer.cc: In member function 'virtual epicsTimerNotify::expireStatus gateRateStatsTimer::expire(const epicsTime&)':
../gateServer.cc:51:49: error: 'ALL_PROCESSOR_GROUPS' was not declared in this scope
     #define NO_OF_CPUS GetMaximumProcessorCount(ALL_PROCESSOR_GROUPS)
                                                 ^
../gateServer.cc:2202:31: note: in expansion of macro 'NO_OF_CPUS'
       (delTime*CLOCKS_PER_SEC*NO_OF_CPUS):0.0;
                               ^
../gateServer.cc:51:49: note: suggested alternative: '_PROCESSOR_GROUP_INFO'
     #define NO_OF_CPUS GetMaximumProcessorCount(ALL_PROCESSOR_GROUPS)
                                                 ^
../gateServer.cc:2202:31: note: in expansion of macro 'NO_OF_CPUS'
       (delTime*CLOCKS_PER_SEC*NO_OF_CPUS):0.0;
                               ^
../gateServer.cc:51:24: error: 'GetMaximumProcessorCount' was not declared in this scope
     #define NO_OF_CPUS GetMaximumProcessorCount(ALL_PROCESSOR_GROUPS)
                        ^
../gateServer.cc:2202:31: note: in expansion of macro 'NO_OF_CPUS'
       (delTime*CLOCKS_PER_SEC*NO_OF_CPUS):0.0;
                               ^
../gateServer.cc:51:24: note: suggested alternative: 'GetNumaProcessorNode'
     #define NO_OF_CPUS GetMaximumProcessorCount(ALL_PROCESSOR_GROUPS)
                        ^
../gateServer.cc:2202:31: note: in expansion of macro 'NO_OF_CPUS'
       (delTime*CLOCKS_PER_SEC*NO_OF_CPUS):0.0;
                               ^
make[2]: *** [/mnt/build/prefix/configure/RULES_BUILD:262: gateServer.o] Error 1
make[2]: *** Waiting for unfinished jobs....
make[2]: Leaving directory '/mnt/build/support/ca-gateway/src/O.windows-x64-mingw'
make[1]: *** [/mnt/build/prefix/configure/RULES_ARCHS:62: windows-x64-mingw] Error 2
make[1]: Leaving directory '/mnt/build/support/ca-gateway/src'
make: *** [/mnt/build/prefix/configure/RULES_DIRS:85: src.windows-x64-mingw] Error 2
```