### PR TITLE
Don't throw KeyError if BASE not in os.environ[]

### DIFF
--- a/testTop/pyTestsApp/TestStructures.py
+++ b/testTop/pyTestsApp/TestStructures.py
@@ -58,7 +58,7 @@ class TestStructures(unittest.TestCase):
                 .format(k, str(self.gwStruct[k]), str(self.iocStruct[k])))
         return are_diff, diffs
 
-    @unittest.skipIf(os.environ['BASE'] == "3.14", "updates of CTRL structures are buggy in 3.14 PCAS")
+    @unittest.skipIf(os.environ.get('BASE') == "3.14", "updates of CTRL structures are buggy in 3.14 PCAS")
     def testCtrlStruct_ValueMonitor(self):
         '''Monitor PV (value events) through GW - change value and properties directly - check CTRL structure consistency'''
         diffs = []


### PR DESCRIPTION
No reason to throw an error on this.   No requirement in EPICS to define an env variable named BASE.