### PR TITLE
Gateway diags

### DIFF
--- a/src/gatePv.cc
+++ b/src/gatePv.cc
@@ -1424,6 +1424,7 @@ void gatePvData::eventCB(EVENT_ARGS args)
 					   dd,
 					   pv->needAddRemove());
 #endif
+                dumpdd(1, "gatePvData::eventCB setEventData", pv->name(), dd);
 				stat_sevr_changed = pv->vc->setEventData(dd);
 
 				if(pv->needAddRemove())
@@ -1501,6 +1502,7 @@ void gatePvData::logEventCB(EVENT_ARGS args)
 					   dd,
 					   pv->needAddRemove());
 #endif
+                dumpdd(1, "gatePvData::logEventCB setEventData", pv->name(), dd);
 				pv->vc->setEventData(dd);
 
 				if(pv->needAddRemove())
@@ -1569,6 +1571,9 @@ void gatePvData::propEventCB(EVENT_ARGS args)
 #endif
                 // Update attribute cache
                 gateDebug2(3,"gatePvData::propEventCB() %s PV %s setPvData\n",pv->getStateName(),pv->name());
+#if DEBUG_ENUM
+                dumpdd(1, "gatePvData::propEventCB setPvData", pv->name(), dd);
+#endif
                 pv->vc->setPvData(dd);
             }
 
@@ -1579,7 +1584,10 @@ void gatePvData::propEventCB(EVENT_ARGS args)
                 printf("  dd=%p needAddRemove=%d\n", dd, pv->needAddRemove());
 #endif
                 gateDebug2(3,"gatePvData::propEventCB() %s PV %s setEventData\n",pv->getStateName(),pv->name());
-                pv->vc->setEventData(dd);
+#if DEBUG_ENUM
+                dumpdd(1, "gatePvData::propEventCB setEventData", pv->name(), dd);
+#endif
+                pv->vc->setEventData(dd);	// Create new setPropData()???
 
                 if (pv->needAddRemove())
                 {
@@ -1705,8 +1713,10 @@ void gatePvData::getCB(EVENT_ARGS args)
                 // Update value cache with received data
                 gateDebug2(3,"gatePvData::getCB() %s PV %s runValueDataCB\n",pv->getStateName(),pv->name());
                 dd = pv->runValueDataCB(&args);
-                if (dd)
+                if (dd) {
+                    dumpdd(1, "gatePvData::getCB setEventData", pv->name(), dd);
                     pv->vc->setEventData(dd);
+				}
 
                 if (pv->needAddRemove() && !pv->vc->needPosting()) {
                     gateDebug0(5, "gatePvData::getCB() need add/remove\n");
@@ -1769,8 +1779,10 @@ void gatePvData::getTimeCB(EVENT_ARGS args)
 		{
 			gateDebug1(5,"gatePvData::getTimeCB() %s PV\n",pv->getStateName());
             dd = pv->runEventCB(&args);
-            if (dd)
+            if (dd) {
+                dumpdd(1, "gatePvData::getTimeCB setEventData", pv->name(), dd);
                 pv->vc->setEventData(dd);
+            }
 
 			/* flush async get request */
 			if(pv->needAddRemove() && !pv->vc->needPosting())
@@ -2073,8 +2085,8 @@ gdd* gatePvData::eventEnumCB(EVENT_ARGS * pArgs)
 		value->putConvert(ts->value);
 	}
 #if DEBUG_ENUM
-	printf("gatePvData::eventEnumCB\n");
-	value->dump();
+    printf("gatePvData::eventEnumCB\n");
+    dumpdd(1, "gatePvData::eventEnumCB", name(), value);
 #endif
 	value->setStatSevr(ts->status,ts->severity);
 	value->setTimeStamp(&ts->stamp);
@@ -2291,8 +2303,8 @@ gdd* gatePvData::valueDataEnumCB(EVENT_ARGS * pArgs)
 		value->putConvert(ts->value);
 	}
 #if DEBUG_ENUM
-	printf("gatePvData::valueDataEnumCB\n");
-	value->dump();
+    printf("gatePvData::valueDataEnumCB\n");
+    dumpdd(1, "gatePvData::valueDataEnumCB", name(), value);
 #endif
 	value->setStatSevr(ts->status,ts->severity);
 	return value;

--- a/src/gatePv.cc
+++ b/src/gatePv.cc
@@ -1554,27 +1554,31 @@ void gatePvData::propEventCB(EVENT_ARGS args)
         // only sends event_data and does ADD transactions
         if(pv->active())
         {
-            gateDebug2(5,"gatePvData::propEventCB() %s PV %d\n",pv->getStateName(), pv->propGetPending());
+            gateDebug3(5,"gatePvData::propEventCB() %s PV %s propGetPending %d\n",pv->getStateName(),pv->name(),pv->propGetPending());
             if(pv->propGetPending()) {
-                gateDebug1(5,"gatePvData::propEventCB() Ignore first event %s PV\n",pv->getStateName());
+                gateDebug1(5,"gatePvData::propEventCB() Ignore first propEvent %s PV\n",pv->getStateName());
                 pv->markPropNoGetPending();
                 return;
             }
 
+            gateDebug1(3,"gatePvData::propEventCB() %s PV runDataCB\n",pv->getStateName());
             if ((dd = pv->runDataCB(&args)))  // Create the attributes gdd
             {
 #if DEBUG_BEAM
                 printf("  dd=%p needAddRemove=%d\n", dd, pv->needAddRemove());
 #endif
                 // Update attribute cache
+                gateDebug2(3,"gatePvData::propEventCB() %s PV %s setPvData\n",pv->getStateName(),pv->name());
                 pv->vc->setPvData(dd);
             }
 
+            gateDebug2(4,"gatePvData::propEventCB() %s PV %s runValueDataCB\n",pv->getStateName(),pv->name());
             if ((dd = pv->runValueDataCB(&args)))  // Create the value gdd
             {
 #if DEBUG_BEAM
                 printf("  dd=%p needAddRemove=%d\n", dd, pv->needAddRemove());
 #endif
+                gateDebug2(3,"gatePvData::propEventCB() %s PV %s setEventData\n",pv->getStateName(),pv->name());
                 pv->vc->setEventData(dd);
 
                 if (pv->needAddRemove())
@@ -1670,7 +1674,7 @@ void gatePvData::getCB(EVENT_ARGS args)
     pv->markNoCtrlGetPending();
     if (pv->active()) {
         if (args.status == ECA_NORMAL) {
-            gateDebug1(5,"gatePvData::getCB() %s PV\n",pv->getStateName());
+            gateDebug2(5,"gatePvData::getCB() %s PV %s runDataCB\n",pv->getStateName(),pv->name());
             // Update property cache with received property data
             dd = pv->runDataCB(&args);
             if (dd)
@@ -1699,6 +1703,7 @@ void gatePvData::getCB(EVENT_ARGS args)
 
             if (args.status == ECA_NORMAL) {
                 // Update value cache with received data
+                gateDebug2(3,"gatePvData::getCB() %s PV %s runValueDataCB\n",pv->getStateName(),pv->name());
                 dd = pv->runValueDataCB(&args);
                 if (dd)
                     pv->vc->setEventData(dd);
@@ -2033,7 +2038,7 @@ gdd* gatePvData::eventStringCB(EVENT_ARGS * pArgs)
 
 gdd* gatePvData::eventEnumCB(EVENT_ARGS * pArgs)
 {
-	gateDebug0(10,"gatePvData::eventEnumCB\n");
+    gateDebug1(10,"gatePvData::eventEnumCB PV %s\n", name());
     dbr_time_enum* ts = (dbr_time_enum*)pArgs->dbr;
     aitIndex maxCount = totalElements();
 	gdd* value;
@@ -2073,6 +2078,7 @@ gdd* gatePvData::eventEnumCB(EVENT_ARGS * pArgs)
 #endif
 	value->setStatSevr(ts->status,ts->severity);
 	value->setTimeStamp(&ts->stamp);
+	gateDebug3(12,"gatePvData::eventEnumCB PV %s secPastEpoch=%u, nsec=%u \n", name(), ts->stamp.secPastEpoch, ts->stamp.nsec);
 	return value;
 }
 

--- a/src/gatePv.h
+++ b/src/gatePv.h
@@ -214,7 +214,10 @@ private:
 	void markAbort(void) { abort_flag=1; }
 	void markNoAbort(void) { abort_flag=0; }
 
-	void setState(gatePvState s) { pv_state=s; }
+	void setState(gatePvState s) {
+		pv_state=s;
+		gateDebug2(3,"gatePvData::setState PV %s: %s\n", name(), getStateName());
+	}
 
     gdd* runEventCB(EVENT_ARGS *pArgs) { return (this->*event_func)(pArgs); }
     gdd* runDataCB(EVENT_ARGS *pArgs) { return (this->*data_func)(pArgs); }

--- a/src/gatePv.h
+++ b/src/gatePv.h
@@ -214,10 +214,10 @@ private:
 	void markAbort(void) { abort_flag=1; }
 	void markNoAbort(void) { abort_flag=0; }
 
-	void setState(gatePvState s) {
-		pv_state=s;
-		gateDebug2(3,"gatePvData::setState PV %s: %s\n", name(), getStateName());
-	}
+    void setState(gatePvState s) {
+        pv_state=s;
+        gateDebug2(3,"gatePvData::setState PV %s: %s\n", name(), getStateName());
+    }
 
     gdd* runEventCB(EVENT_ARGS *pArgs) { return (this->*event_func)(pArgs); }
     gdd* runDataCB(EVENT_ARGS *pArgs) { return (this->*data_func)(pArgs); }

--- a/src/gateVc.cc
+++ b/src/gateVc.cc
@@ -77,7 +77,7 @@ void dumpdd(int step, const char *desc, const char * pvname, const gdd *dd)
 {
 //	if(strcmp(name,"evans:perf:c3.SCAN")) return;
 	fflush(stderr);
-	printf("(%d) PV %s *******************************\n", step, pvname);
+    printf("(%d) PV %s *******************************\n", step, pvname);
 	if (!dd) {
 		printf("%-25s ===== no gdd here (NULL pointer) =====\n",
 			   desc);
@@ -771,6 +771,7 @@ void gateVcData::setPvData(gdd* dd)
 
 #if DEBUG_GDD
     heading("gateVcData::setPvData",name());
+    dumpdd(1,"pv_data (old property data)",name(),pv_data);
     dumpdd(1,"dd (new property data)",name(),dd);
 #endif
 
@@ -914,9 +915,12 @@ void gateVcData::copyState(gdd &dd)
 			}
 			convertContainerMemberToAtomic(dd, gddAppType_value, count);
 		}
+#if DEBUG_GDD || DEBUG_ENUM
+        dumpdd(5,"dd(before event_data)",name(),&dd);
+        dumpdd(4,"copyState (new event_data)",name(),event_data);
+#endif
 		table.smartCopy(&dd,event_data);
 #if DEBUG_GDD || DEBUG_ENUM
-		dumpdd(4,"event_data",name(),event_data);
 		dumpdd(5,"dd(after event_data)",name(),&dd);
 #endif
 #if DEBUG_EVENT_DATA

--- a/src/gateVc.cc
+++ b/src/gateVc.cc
@@ -73,12 +73,11 @@ void heading(const char *funcname, const char *pvname)
 	fflush(stdout);
 }
 
-void dumpdd(int step, const char *desc, const char * /*name*/, const gdd *dd)
+void dumpdd(int step, const char *desc, const char * pvname, const gdd *dd)
 {
 //	if(strcmp(name,"evans:perf:c3.SCAN")) return;
 	fflush(stderr);
-	printf("(%d) ***********************************************************\n",
-	  step);
+	printf("(%d) PV %s *******************************\n", step, pvname);
 	if (!dd) {
 		printf("%-25s ===== no gdd here (NULL pointer) =====\n",
 			   desc);

--- a/src/gateVc.cc
+++ b/src/gateVc.cc
@@ -578,7 +578,8 @@ int gateVcData::setEventData(gdd* dd)
 	gateDebug2(10,"gateVcData::setEventData(dd=%p) name=%s\n",(void *)dd,name());
 
 #if DEBUG_GDD
-	heading("gateVcData::setEventData",name());
+    heading("gateVcData::setEventData",name());
+    dumpdd(1,"event_data (old value data)",name(),event_data);
     dumpdd(1,"dd (new value data)",name(),dd);
 #endif
 

--- a/src/gateVc.h
+++ b/src/gateVc.h
@@ -273,6 +273,9 @@ inline void gateVcData::addChan(gateVcChan* chan) { chan_list.add(*chan); }
 inline void gateVcData::removeChan(gateVcChan* chan) {
 	chan_list.remove(*chan); chan->setCasPv(NULL); }
 
+// ---------------------------- utilities ------------------------------------
+extern void heading(const char *funcname, const char *pvname);
+extern void dumpdd(int step, const char *desc, const char * pvname, const gdd *dd);
 #endif
 
 /* **************************** Emacs Editing Sequences ***************** */


### PR DESCRIPTION
None of these commits are essential, but I think they help.
For example, if you enable DEBUG_GDD, you can follow the gdd dumps via grep and see which ones have valid timestamps:
```
% egrep dumpdd: j_test7.out  | head
dumpdd:1  ioc:fillingwaveform.NORD at=16[value] pt=0[aitInvalid], sec=0 nsec=0 gateVcData::read dd(incoming)
dumpdd:1  ioc:fillingwaveform.NORD at=21[attributes] pt=12[aitContainer], sec=0 nsec=0 gateVcData::setPvData dd (new property data)
dumpdd:20 ioc:fillingwaveform.NORD at=16[value] pt=9[aitFloat64], sec=1021226851 nsec=32659257 gatePvData::eventCB
dumpdd:1  ioc:fillingwaveform.NORD at=16[value] pt=9[aitFloat64], sec=1021226851 nsec=32659257 gateVcData::setEventData (new value data)
dumpdd:4  ioc:fillingwaveform.NORD at=16[value] pt=9[aitFloat64], sec=1021226851 nsec=32659257 gateVcData::setEventData event_data(after)
dumpdd:1  ioc:fillingwaveform.NORD at=16[value] pt=0[aitInvalid], sec=0 nsec=0 gateVcData::flushAsyncReadQueue asyncr->DD()(before)
dumpdd:1  ioc:fillingwaveform.NORD at=16[value] pt=0[aitInvalid], sec=0 nsec=0 gateVcData::copyState dd(incoming)
dumpdd:2  ioc:fillingwaveform.NORD at=21[attributes] pt=12[aitContainer], sec=0 nsec=0 gateVcData::copyState pv_data
dumpdd:3  ioc:fillingwaveform.NORD at=16[value] pt=0[aitInvalid], sec=0 nsec=0 gateVcData::copyState dd(after pv_data)
dumpdd:4  ioc:fillingwaveform.NORD at=16[value] pt=9[aitFloat64], sec=1021226851 nsec=32659257 gateVcData::copyState event_data
```
