### PR TITLE
document that -sip can take a list of IP addresses

### DIFF
--- a/contrib/START.server
+++ b/contrib/START.server
@@ -11,7 +11,7 @@
 # export EPICS_CA_ADDR_LIST=164.54.189.255
 
 # Other important variables to remember (gateway sets these)
-# export EPICS_CAS_INTF_ADDR= - IP address where server listens
+# export EPICS_CAS_INTF_ADDR_LIST= - IP address list where server listens
 # export EPICS_CAS_SERVER_PORT= - port that the CA server uses
 # export EPICS_CA_SERVER_PORT= - port that the CA client library uses
 

--- a/docs/Gateway.html
+++ b/docs/Gateway.html
@@ -329,9 +329,10 @@ later.
         variable GATEWAY_HOME also accomplishes the same result.</td>
     </tr>
     <tr>
-      <td>-sip &lt;ip-address&gt;</td>
-      <td>IP address where the Gateway server listens for process variable
-        requests. Sets the environment variable EPICS_CAS_INTF_ADDR.</td>
+      <td>-sip &lt;ip-address-list&gt;</td>
+      <td>List of IP address where the Gateway server listens for process
+        variable requests. Sets the environment variable
+        EPICS_CAS_INTF_ADDR_LIST.</td>
     </tr>
     <tr>
       <td>-signore &lt;ip-address-list&gt;</td>

--- a/src/gateway.cc
+++ b/src/gateway.cc
@@ -1389,8 +1389,8 @@ static void print_instructions(void)
 	pr(stderr,"-home directory: Home directory where all your gateway\n");
 	pr(stderr," configuration files are kept where log and command files go.\n\n");
 
-	pr(stderr,"-sip IP_address: IP address that gateway's CA server listens\n");
-	pr(stderr," for PV requests.  Sets env variable EPICS_CAS_INTF_ADDR.\n\n");
+	pr(stderr,"-sip IP_address_list: IP address list that gateway's CA server listens\n");
+	pr(stderr," for PV requests.  Sets env variable EPICS_CAS_INTF_ADDR_LIST.\n\n");
 
 	pr(stderr,"-signore IP_address_list: IP address that gateway's CA server\n");
 	pr(stderr," ignores.  Sets env variable EPICS_CAS_IGNORE_ADDR_LIST.\n\n");


### PR DESCRIPTION
It seems that the ca-gateway has had support for specifying an address list to `-sip` since November 1996: fb769bbd9d78fabaf2ece274013a4c281d254955