### PR TITLE
Update to PCRE2 and drop legacy PCRE support

### DIFF
--- a/configure/CONFIG_SITE
+++ b/configure/CONFIG_SITE
@@ -12,24 +12,23 @@
 # CA Gateway specific settings
 #######################################################################
 
-# Use Perl compatible regular expressions (PCRE) instead of basic regex
-#USE_PCRE=YES
+# Use Perl compatible regular expressions (PCRE2) instead of basic regex
+#USE_PCRE2=YES
 
-# For PCRE on Linux
-#    requires package pcre-devel (or libpcre3-dev) for compiling
-#    requires package pcre (or libpcre3) for running the Gateway
+# For PCRE2 on Linux
+#    requires package libpcre2-dev (or pcre2-devel) for compiling
+#    requires package libpcre2-8 (or pcre2) for running the Gateway
 
 ifeq ($(OS_CLASS),WIN32)
 
-    # For PCRE on Windows
-    #    install libraries and includes from
-    #    https://sourceforge.net/projects/gnuwin32/files/pcre/7.0/pcre-7.0.exe/download
-    #    and set the install location here
-    PCRE_DIR=C:/Pcre
+    # For PCRE2 on Windows
+    #    PCRE2 releases are at https://github.com/PCRE2Project/pcre2/releases
+    #    install libraries and includes and set the install location here
+    PCRE_DIR=C:/Pcre2
 
     # For REGEX on Windows
     #    compile gnuregex inside an EPICS support module from the sources at
-    #    http://www.aps.anl.gov/epics/download/extensions/gnuregex0_13.tar.gz
+    #    https://epics.anl.gov/download/extensions/gnuregex0_13.tar.gz
     #    and set the module location here
     REGEX_DIR=C:/epics/modules/regex
 

--- a/docs/Gateway.html
+++ b/docs/Gateway.html
@@ -435,7 +435,7 @@ later.
       <td>-no_cache</td>
       <td>Do not use cached (monitored) values when a client does ca_get.
         This results in higher network traffic to the IOC but returns always
-        the current value, even if no monitor event had been send 
+        the current value, even if no monitor event had been send
         (e.g. because of a MDEL). This also solves problems with record
         fields like HOPR or EGU if they are modified during run-time.
       </td>
@@ -625,11 +625,12 @@ distribution may be more recent.</p>
 what process variable name patterns are allowed or denied and to optionally
 associate patterns with access security groups and security levels in the
 access file. The patterns are either Perl compatible regular expressions
-(PCRE) or GNU-style regular expressions, depending on the USE_PCRE variable
-in Makefile. (See a UNIX book for more information about regular expressions.)
-In addition, inverted regular experessions (starting with !) are supported
+(PCRE2) or GNU-style regular expressions, depending on the USE_PCRE2 variable
+in Makefile.</p>
+
+<p>In addition, inverted regular experessions (starting with !) are supported
 depending on the USE_NEG_REGEXP variable in Makefile. For compatibility
-with earlier versions of the gateway, PCRE and inverted regular expressions
+with earlier versions of the gateway, PCRE2 and inverted regular expressions
 are disable by default. There is a sample file,
 gateway.pvlist, in the source distribution and reproduced <a
 href="GATEWAY.pvlist">here</a> to get you started. The version in the

--- a/src/Makefile
+++ b/src/Makefile
@@ -25,35 +25,20 @@ ifeq ($(CMPLR_CLASS),msvc)
   USR_LDFLAGS_WIN32 += /SUBSYSTEM:CONSOLE
 endif
 
-ifeq ($(USE_PCRE),YES)
-  USR_CXXFLAGS += -DUSE_PCRE
+ifeq ($(USE_PCRE2),YES)
+  USR_CXXFLAGS += -DUSE_PCRE2
   ifeq ($(OS_CLASS),WIN32)
-    ifneq (,$(wildcard $(PCRE_DIR)/inc/*.h))
-      # Legacy nonstandard pcre3 download and manual install
-      USR_INCLUDES += -I$(PCRE_DIR)/inc
-      PROD_LIBS += pcre3
-      ifeq ($(CMPLR_CLASS),msvc)
-        ifeq ($(T_A),windows-x64)
-          pcre3_DIR = $(PCRE_DIR)/lib/x64
-        else
-          pcre3_DIR = $(PCRE_DIR)/lib
-        endif
-      else
-        pcre3_DIR = $(PCRE_DIR)/bin
-      endif
+    ifdef PCRE_DIR
+      # Modern or MSYS2 pcre used in Windows context
+      USR_INCLUDES += -I$(PCRE_DIR)/include
+      PROD_LIBS += pcre2-8
+      pcre2-8_DIR = $(PCRE_DIR)/lib
     else
-      ifdef PCRE_DIR
-        # Modern or MSYS2 pcre used in Windows context
-        USR_INCLUDES += -I$(PCRE_DIR)/include
-        PROD_LIBS += pcre
-        pcre_DIR = $(PCRE_DIR)/lib
-      else
-        # MSYS2 package pcre-devel used in MSYSTEM context
-        USR_SYS_LIBS += pcre
-      endif
-    endif      
+      # MSYS2 package pcre2-devel used in MSYSTEM context
+      USR_SYS_LIBS += pcre2-8
+    endif
   else
-    USR_SYS_LIBS += pcre
+    USR_SYS_LIBS += pcre2-8
   endif
 else
   # On Linux basic regex is part of libc

--- a/src/gateAs.cc
+++ b/src/gateAs.cc
@@ -60,12 +60,12 @@ FILE* gateAs::rules_fd = NULL;
 
 // extern "C" wrappers needed for callbacks
 extern "C" {
-	static void clientCallback(ASCLIENTPVT p, asClientStatus s) {
-		gateAsClient::clientCallback(p, s);
-	}
-	static int readFunc(char* buf, int max_size) {
-		return gateAs::readFunc(buf, max_size);
-	}
+        static void clientCallback(ASCLIENTPVT p, asClientStatus s) {
+                gateAsClient::clientCallback(p, s);
+        }
+        static int readFunc(char* buf, int max_size) {
+                return gateAs::readFunc(buf, max_size);
+        }
 }
 
 // pattern  PV name pattern (regex)
@@ -74,118 +74,119 @@ extern "C" {
 // asl      ASL
 gateAsEntry::gateAsEntry(const char* pattern, const char* realname, const char* asg,
   int asl) :
-	pattern(pattern),
-	alias(realname),
-	group(asg),
-	level(asl),
-	asmemberpvt(NULL)
+        pattern(pattern),
+        alias(realname),
+        group(asg),
+        level(asl),
+        asmemberpvt(NULL)
 {
-#ifdef USE_PCRE
-	pat_buff = NULL;
-	ovector = NULL;
-	ovecsize = 0;
+#ifdef USE_PCRE2
+        pat_buff = NULL;
+        match_data = NULL;
+        ovector = NULL;
+        ovecsize = 0;
 #else
-	// Set pointers in the pattern buffer
-	pat_buff.buffer=NULL;
-	pat_buff.translate=NULL;
-	pat_buff.fastmap=NULL;
+        // Set pointers in the pattern buffer
+        pat_buff.buffer=NULL;
+        pat_buff.translate=NULL;
+        pat_buff.fastmap=NULL;
 
-	// Initialize registers
-	re_set_registers(&pat_buff,&regs,0,0,0);
+        // Initialize registers
+        re_set_registers(&pat_buff,&regs,0,0,0);
 #endif
 }
 
 gateAsEntry::~gateAsEntry(void)
 {
-	// Free allocated stuff in the pattern buffer
-#ifdef USE_PCRE
-	pcre_free(pat_buff);
-	pcre_free(ovector);
+        // Free allocated stuff in the pattern buffer
+#ifdef USE_PCRE2
+        if(pat_buff) pcre2_code_free(pat_buff);
+        if(match_data) pcre2_match_data_free(match_data);
 #else
-	regfree(&pat_buff);
-	// Free allocted stuff in registers
-	if(regs.start) free(regs.start);
-	if(regs.end) free(regs.end);
-	regs.num_regs=0;
+        regfree(&pat_buff);
+        // Free allocted stuff in registers
+        if(regs.start) free(regs.start);
+        if(regs.end) free(regs.end);
+        regs.num_regs=0;
 #endif
 }
 
 long gateAsEntry::removeMember(void)
 {
-	long rc=0;
-	if(asmemberpvt) {
-		rc=asRemoveMember(&asmemberpvt);
-		if(rc == S_asLib_clientsExist) {
-			printf("Cannot remove member because client exists for:\n");
-			printf(" %-30s %-16s %d ",pattern,group,level);
-		}
-		asmemberpvt=NULL;
-	}
-	return rc;
+        long rc=0;
+        if(asmemberpvt) {
+                rc=asRemoveMember(&asmemberpvt);
+                if(rc == S_asLib_clientsExist) {
+                        printf("Cannot remove member because client exists for:\n");
+                        printf(" %-30s %-16s %d ",pattern,group,level);
+                }
+                asmemberpvt=NULL;
+        }
+        return rc;
 }
 
-void gateAsEntry::getRealName(const char* pv, char* rname, int len)
+void gateAsEntry::getRealName(const char* pv, char* rname, size_t len)
 {
-	char c;
-	int in, ir, j, n;
+        char c;
+        int in, ir, j, n;
 
-	if (alias) {  // Build real name from substitution pattern
-		ir = 0;
-		for (in=0; ir<len; in++) {
-			if ((c = alias[in]) == '\\') {
-				c = alias[++in];
-				if(c >= '0' && c <= '9') {
-					n = c - '0';
-#ifdef USE_PCRE
-					if(n < substrings && ovector[2*n] >= 0) {
-						for(j=ovector[2*n];
-							ir<len && j<ovector[2*n+1];
-							j++)
-						  rname[ir++] = pv[j];
-						if(ir==len)	{
-							rname[ir-1] = '\0';
-							break;
-						}
-					}
+        if (alias) {  // Build real name from substitution pattern
+                ir = 0;
+                for (in=0; ir<len; in++) {
+                        if ((c = alias[in]) == '\\') {
+                                c = alias[++in];
+                                if(c >= '0' && c <= '9') {
+                                        n = c - '0';
+#ifdef USE_PCRE2
+                                        if(n < substrings && ovector[2*n] != PCRE2_UNSET) {
+                                                for(j=(int)ovector[2*n];
+                                                        ir<len && j<(int)ovector[2*n+1];
+                                                        j++)
+                                                  rname[ir++] = pv[j];
+                                                if(ir==len)	{
+                                                        rname[ir-1] = '\0';
+                                                        break;
+                                                }
+                                        }
 #else
-					if(regs.start[n] >= 0) {
-						for(j=regs.start[n];
-							ir<len && j<regs.end[n];
-							j++)
-						  rname[ir++] = pv[j];
-						if(ir==len)	{
-							rname[ir-1] = '\0';
-							break;
-						}
-					}
+                                        if(regs.start[n] >= 0) {
+                                                for(j=regs.start[n];
+                                                        ir<len && j<regs.end[n];
+                                                        j++)
+                                                  rname[ir++] = pv[j];
+                                                if(ir==len)	{
+                                                        rname[ir-1] = '\0';
+                                                        break;
+                                                }
+                                        }
 #endif
-					continue;
-				}
-			}
-			rname[ir++] = c;
-			if(c) continue;
-			else break;
-		}
-		if(ir==len) rname[ir-1] = '\0';
-		gateDebug4(6,"gateAsEntry::getRealName() PV %s matches %s -> alias %s"
-		  " yields real name %s\n",
-		  pv, pattern, alias, rname);
-	} else {
-		// Not an alias: PV name _is_ real name
-		strncpy(rname, pv, len);
-	}
+                                        continue;
+                                }
+                        }
+                        rname[ir++] = c;
+                        if(c) continue;
+                        else break;
+                }
+                if(ir==len) rname[ir-1] = '\0';
+                gateDebug4(6,"gateAsEntry::getRealName() PV %s matches %s -> alias %s"
+                  " yields real name %s\n",
+                  pv, pattern, alias, rname);
+        } else {
+                // Not an alias: PV name _is_ real name
+                strncpy(rname, pv, len);
+        }
     return;
 }
 
 aitBool gateAsEntry::init(gateAsList& n, int line) {
-	if (compilePattern(line)==aitFalse) return aitFalse;
-	n.add(*this);
-	if (group == NULL || asAddMember(&asmemberpvt,(char*)group) != 0) {
-		asmemberpvt = NULL;
-	} else {
-		asPutMemberPvt(asmemberpvt,this);
-	}
-	return aitTrue;
+        if (compilePattern(line)==aitFalse) return aitFalse;
+        n.add(*this);
+        if (group == NULL || asAddMember(&asmemberpvt,(char*)group) != 0) {
+                asmemberpvt = NULL;
+        } else {
+                asPutMemberPvt(asmemberpvt,this);
+        }
+        return aitTrue;
 }
 
 #ifdef USE_DENYFROM
@@ -193,139 +194,144 @@ aitBool gateAsEntry::init(const char* host,	// Host name to deny
   tsHash<gateAsList>& h,                // Where this entry is added to
   gateHostList& hl,				        // Where a new key should be added
   int line) {					        // Line number
-	gateAsList* l;
+        gateAsList* l;
 
-	if(compilePattern(line)==aitFalse) return aitFalse;
-	if(h.find(host,l)==0) {
-		l->add(*this);
-	} else {
-		l = new gateAsList;
-		l->add(*this);
-		h.add(host,*l);
-		hl.add(*(new gateAsHost(host)));
-	}
-	return aitTrue;
+        if(compilePattern(line)==aitFalse) return aitFalse;
+        if(h.find(host,l)==0) {
+                l->add(*this);
+        } else {
+                l = new gateAsList;
+                l->add(*this);
+                h.add(host,*l);
+                hl.add(*(new gateAsHost(host)));
+        }
+        return aitTrue;
 }
 #endif
 
 aitBool gateAsEntry::compilePattern(int line) {
-	const char *err;
+        const char *err;
 
 #ifdef USE_NEG_REGEXP
         negate_pattern = (pattern[0] == '!');
         if (negate_pattern) pattern++;
 #endif
 
-#ifdef USE_PCRE
-	int erroffset;
-        pat_buff = pcre_compile(pattern, 0, &err, &erroffset, NULL);
-	if(!pat_buff)	{
-		fprintf(stderr,"Line %d: Error after %d chars in Perl regexp: %s\n",
-                    line, erroffset, err);
+#ifdef USE_PCRE2
+        int errcode;
+        size_t erroffset;
+        pat_buff = pcre2_compile((PCRE2_SPTR)pattern, PCRE2_ZERO_TERMINATED, 0, &errcode, &erroffset, NULL);
+        if(!pat_buff)	{
+                PCRE2_UCHAR buffer[256];
+                pcre2_get_error_message(errcode, buffer, sizeof(buffer));
+                fprintf(stderr,"Line %d: Error after %d chars in Perl regexp: %s\n",
+                    line, (int)erroffset, (char*)buffer);
                 fprintf(stderr,"%s\n", pattern);
-                fprintf(stderr,"%*c\n", erroffset+1, '^');
-		return aitFalse;
-	}
-        pcre_fullinfo(pat_buff, NULL, PCRE_INFO_CAPTURECOUNT, &ovecsize);
-        ovecsize = (ovecsize+1)*3;
-        ovector = (int*) pcre_malloc (sizeof(int)*ovecsize);
+                fprintf(stderr,"%*c\n", (int)erroffset+1, '^');
+                return aitFalse;
+        }
+        match_data = pcre2_match_data_create_from_pattern(pat_buff, NULL);
+        ovector = pcre2_get_ovector_pointer(match_data);
+        uint32_t count;
+        pcre2_pattern_info(pat_buff, PCRE2_INFO_CAPTURECOUNT, &count);
+        substrings = count + 1;
 #else
-	pat_buff.translate=0; pat_buff.fastmap=0;
-	pat_buff.allocated=0; pat_buff.buffer=0;
+        pat_buff.translate=0; pat_buff.fastmap=0;
+        pat_buff.allocated=0; pat_buff.buffer=0;
 
     if((err = re_compile_pattern(pattern, (int) strlen(pattern), &pat_buff)))	{
-		fprintf(stderr,"Line %d: Error in regexp %s : %s\n", line, pattern, err);
-		return aitFalse;
-	}
+                fprintf(stderr,"Line %d: Error in regexp %s : %s\n", line, pattern, err);
+                return aitFalse;
+        }
 #endif
 #ifdef USE_NEG_REGEXP
         if (negate_pattern) pattern--;
 #endif
-	return aitTrue;
+        return aitTrue;
 }
 
 gateAsClient::gateAsClient(void) :
-	asclientpvt(NULL),
-	asentry(NULL),
-	user_arg(NULL),
-	user_func(NULL)
+        asclientpvt(NULL),
+        asentry(NULL),
+        user_arg(NULL),
+        user_func(NULL)
 {
 }
 
 gateAsClient::gateAsClient(gateAsEntry *pEntry, const char *user,
   const char *host) :
-	asclientpvt(NULL),
-	asentry(pEntry),
-	user_arg(NULL),
-	user_func(NULL)
+        asclientpvt(NULL),
+        asentry(pEntry),
+        user_arg(NULL),
+        user_func(NULL)
 {
-	if(pEntry&&asAddClient(&asclientpvt,pEntry->asmemberpvt,pEntry->level,
-		 (char*)user,(char*)host) == 0) {
-		asPutClientPvt(asclientpvt,this);
-	}
+        if(pEntry&&asAddClient(&asclientpvt,pEntry->asmemberpvt,pEntry->level,
+                 (char*)user,(char*)host) == 0) {
+                asPutClientPvt(asclientpvt,this);
+        }
 
 #if DEBUG_DELAY
-	gateAsClient *v=this;
-	printf("%s gateAsClient::gateAsClient pattern=%s user_func=%d\n",
-	  timeStamp(),
-	  v->asentry?(v->asentry->pattern?v->asentry->pattern:"[NULL pattern]"):"[NULL entry]",
-	  v->user_func);
+        gateAsClient *v=this;
+        printf("%s gateAsClient::gateAsClient pattern=%s user_func=%d\n",
+          timeStamp(),
+          v->asentry?(v->asentry->pattern?v->asentry->pattern:"[NULL pattern]"):"[NULL entry]",
+          v->user_func);
 #endif
 
-	// Callback is called if rights are changed by rereading the
-	// access file, etc.  Callback will be called once right now, but
-	// won't do anything since the user_func is NULL.  The user_func
-	// is set in gateChan::gateChan.
-	asRegisterClientCallback(asclientpvt,::clientCallback);
+        // Callback is called if rights are changed by rereading the
+        // access file, etc.  Callback will be called once right now, but
+        // won't do anything since the user_func is NULL.  The user_func
+        // is set in gateChan::gateChan.
+        asRegisterClientCallback(asclientpvt,::clientCallback);
 
 #if DEBUG_DELAY
-	printf("%s gateAsClient::gateAsClient finished\n",
-	  timeStamp());
+        printf("%s gateAsClient::gateAsClient finished\n",
+          timeStamp());
 #endif
 }
 
 gateAsClient::~gateAsClient(void)
 {
-	// client callback
-	if(asclientpvt) asRemoveClient(&asclientpvt);
-	asclientpvt=NULL;
+        // client callback
+        if(asclientpvt) asRemoveClient(&asclientpvt);
+        asclientpvt=NULL;
 }
 
 void gateAsClient::clientCallback(ASCLIENTPVT p, asClientStatus /*s*/)
 {
-	gateAsClient* pClient = (gateAsClient*)asGetClientPvt(p);
+        gateAsClient* pClient = (gateAsClient*)asGetClientPvt(p);
 #if DEBUG_DELAY
-	printf("%s gateAsClient::clientCallback pattern=%s user_func=%d\n",
-	  timeStamp(),
-	  pClient->asentry?(pClient->asentry->pattern?
-		pClient->asentry->pattern:"[NULL pattern]"):"[NULL entry]",
-	  pClient->user_func);
+        printf("%s gateAsClient::clientCallback pattern=%s user_func=%d\n",
+          timeStamp(),
+          pClient->asentry?(pClient->asentry->pattern?
+                pClient->asentry->pattern:"[NULL pattern]"):"[NULL entry]",
+          pClient->user_func);
 #endif
-	if(pClient->user_func) pClient->user_func(pClient->user_arg);
+        if(pClient->user_func) pClient->user_func(pClient->user_arg);
 }
 
 gateAs::gateAs(const char* lfile, const char* afile)
 #ifdef USE_DENYFROM
-	: denyFromListUsed(false)
+        : denyFromListUsed(false)
 #endif
 {
-	// These are static only so they can be used in readFunc.  Be
-	// careful about having two instances of this class as when
-	// rereading access security.  These variables will be valid for
-	// the last instance only.
-	default_group = "DEFAULT";
-	default_pattern = "*";
-	eval_order = GATE_ALLOW_FIRST;
-	rules_installed = aitFalse;
-	use_default_rules = aitFalse;
-	rules_fd = NULL;
+        // These are static only so they can be used in readFunc.  Be
+        // careful about having two instances of this class as when
+        // rereading access security.  These variables will be valid for
+        // the last instance only.
+        default_group = "DEFAULT";
+        default_pattern = "*";
+        eval_order = GATE_ALLOW_FIRST;
+        rules_installed = aitFalse;
+        use_default_rules = aitFalse;
+        rules_fd = NULL;
 
-	if(afile) {
-		if(initialize(afile))
-		  fprintf(stderr,"Failed to install access security file %s\n",afile);
-	}
+        if(afile) {
+                if(initialize(afile))
+                  fprintf(stderr,"Failed to install access security file %s\n",afile);
+        }
 
-	readPvList(lfile);
+        readPvList(lfile);
 }
 
 gateAs::~gateAs(void)
@@ -333,166 +339,165 @@ gateAs::~gateAs(void)
 #ifdef USE_DENYFROM
 // Probably OK but not checked for reinitializing all of access
 // security including the pvlist.
-	tsSLIter<gateAsHost> pi = host_list.firstIter();
+        tsSLIter<gateAsHost> pi = host_list.firstIter();
     gateAsList * l = NULL;
 
-	gateAsHost *pNode;
-	while(pi.pointer())	{
-		pNode=pi.pointer();
-		deny_from_table.remove(pNode->host,l);
-		clearAsList(*l);
-		pi++;
-	}
-	clearHostList(host_list);
+        gateAsHost *pNode;
+        while(pi.pointer())	{
+                pNode=pi.pointer();
+                deny_from_table.remove(pNode->host,l);
+                clearAsList(*l);
+                pi++;
+        }
+        clearHostList(host_list);
 #endif
 
-	clearAsList(deny_list);
-	clearAsList(allow_list);
-	clearAsList(line_list);
+        clearAsList(deny_list);
+        clearAsList(allow_list);
+        clearAsList(line_list);
 }
 
 // Remove the items from the list and delete them
 void gateAs::clearAsList(gateAsList& list)
 {
-	while(list.first()) {
-		gateAsEntry *pe=list.get();
-		if(pe) {
-			// Remove the member from access security
-			pe->removeMember();
-			delete pe;
-		}
-	}
+        while(list.first()) {
+                gateAsEntry *pe=list.get();
+                if(pe) {
+                        // Remove the member from access security
+                        pe->removeMember();
+                        delete pe;
+                }
+        }
 }
 
 // Remove the items from the list and delete them
 void gateAs::clearAsList(gateLineList& list)
 {
-	while(list.first()) {
-		gateAsLine *pl=list.get();
-		if(pl) delete pl;
-	}
+        while(list.first()) {
+                gateAsLine *pl=list.get();
+                if(pl) delete pl;
+        }
 }
 #ifdef USE_DENYFROM
 // Remove the items from the list and delete them
 void gateAs::clearHostList(gateHostList& list)
 {
-	while(list.first()) {
-		gateAsHost *ph=list.get();
-		if(ph) delete ph;
-	}
+        while(list.first()) {
+                gateAsHost *ph=list.get();
+                if(ph) delete ph;
+        }
 }
 #endif
 
 gateAsEntry* gateAs::findEntryInList(const char* pv, gateAsList& list) const
 {
-	tsSLIter<gateAsEntry> pi = list.firstIter();
+        tsSLIter<gateAsEntry> pi = list.firstIter();
 
-	while(pi.pointer()) {
+        while(pi.pointer()) {
         int len = (int) strlen(pv);
-#ifdef USE_PCRE
-		pi->substrings=pcre_exec(pi->pat_buff, NULL,
-                    pv, len, 0, PCRE_ANCHORED, pi->ovector, 30);
-		if((pi->substrings>=0 && pi->ovector[1] == len)
+#ifdef USE_PCRE2
+                pi->substrings = pcre2_match(pi->pat_buff, (PCRE2_SPTR)pv, len, 0, PCRE2_ANCHORED, pi->match_data, NULL);
+                if((pi->substrings>=0 && pi->ovector[1] == (size_t)len)
 #ifdef USE_NEG_REGEXP
-		    ^ pi->negate_pattern
+                    ^ pi->negate_pattern
 #endif
-		) break;
+                ) break;
 #else
         if((re_match(&pi->pat_buff, pv, len, 0, &pi->regs) == len)
 #ifdef USE_NEG_REGEXP
-		    ^ pi->negate_pattern
+                    ^ pi->negate_pattern
 #endif
-		) break;
+                ) break;
 #endif
-		pi++;
-	}
-	return pi.pointer();
+                pi++;
+        }
+        return pi.pointer();
 }
 
 int gateAs::readPvList(const char* lfile)
 {
-	int line=0;
-	FILE* fd;
-	char inbuf[GATE_MAX_PVLIST_LINE_LENGTH];
+        int line=0;
+        FILE* fd;
+        char inbuf[GATE_MAX_PVLIST_LINE_LENGTH];
 #ifdef USE_DENYFROM
-	char inbufWithIPs[GATE_MAX_PVLIST_LINE_LENGTH];
-	char tempInbuf[GATE_MAX_PVLIST_LINE_LENGTH];
+        char inbufWithIPs[GATE_MAX_PVLIST_LINE_LENGTH];
+        char tempInbuf[GATE_MAX_PVLIST_LINE_LENGTH];
 #endif
-	const char *pattern,*rname,*hname;
-	char *cmd,*asg,*asl,*ptr;
-	gateAsEntry* pe;
-	gateAsLine*  pl;
+        const char *pattern,*rname,*hname;
+        char *cmd,*asg,*asl,*ptr;
+        gateAsEntry* pe;
+        gateAsLine*  pl;
 
 #ifdef USE_DENYFROM
-	denyFromListUsed=false;
+        denyFromListUsed=false;
 #endif
 
-	if(lfile) {
-		errno=0;
-		fd=fopen(lfile,"r");
-		if(fd == NULL) {
-			fprintf(stderr,"Failed to open PV list file %s\n",lfile);
-			fflush(stderr);
-			perror("Reason");
-			fflush(stderr);
-			return -1;
-		}
-	} else {
-		// Create a ".* allow" rule if no file is specified
-		pe = new gateAsEntry(".*",NULL,default_group,1);
-		if(pe->init(allow_list,line)==aitFalse) delete pe;
+        if(lfile) {
+                errno=0;
+                fd=fopen(lfile,"r");
+                if(fd == NULL) {
+                        fprintf(stderr,"Failed to open PV list file %s\n",lfile);
+                        fflush(stderr);
+                        perror("Reason");
+                        fflush(stderr);
+                        return -1;
+                }
+        } else {
+                // Create a ".* allow" rule if no file is specified
+                pe = new gateAsEntry(".*",NULL,default_group,1);
+                if(pe->init(allow_list,line)==aitFalse) delete pe;
 
-		return 0;
-	}
+                return 0;
+        }
 
-	// Read all PV file lines
-	while(fgets(inbuf,sizeof(inbuf),fd)) {
-		int lev=1;
+        // Read all PV file lines
+        while(fgets(inbuf,sizeof(inbuf),fd)) {
+                int lev=1;
 
-		++line;
-		pattern=rname=hname=NULL;
+                ++line;
+                pattern=rname=hname=NULL;
 
 #ifdef USE_DENYFROM
-		//All deny from rules with host names will be conveted to ip addresses
-		strncpy(tempInbuf,inbuf,sizeof(tempInbuf)-1);
-		tempInbuf[sizeof(tempInbuf)-1]='\0';
+                //All deny from rules with host names will be conveted to ip addresses
+                strncpy(tempInbuf,inbuf,sizeof(tempInbuf)-1);
+                tempInbuf[sizeof(tempInbuf)-1]='\0';
 
-		if((ptr=strchr(inbuf,'#'))) *ptr='\0'; // Take care of comments
+                if((ptr=strchr(inbuf,'#'))) *ptr='\0'; // Take care of comments
 
-		if(!(pattern=strtok(inbuf," \t\n"))) continue;
+                if(!(pattern=strtok(inbuf," \t\n"))) continue;
 
-		if(!(cmd=strtok(NULL," \t\n")))	{
-			fprintf(stderr,"Error in PV list file (line %d): "
-			  "missing command\n",line);
-			continue;
-		}
-		if(strcasecmp(cmd,"DENY")==0) {
-			// Arbitrary number of arguments: [from] host names
-			if((hname=strtok(NULL,", \t\n")) && strcasecmp(hname,"FROM")==0)
-			  hname=strtok(NULL,", \t\n");
-			if(hname) {           // host pattern(s) present
-				struct sockaddr_in sockAdd;
-				struct sockaddr_in* pSockAdd;
-				char hostname[GATE_MAX_HOSTNAME_LENGTH];
-				int status;
-				char *ch;
-				char *pIPInput;
+                if(!(cmd=strtok(NULL," \t\n")))	{
+                        fprintf(stderr,"Error in PV list file (line %d): "
+                          "missing command\n",line);
+                        continue;
+                }
+                if(strcasecmp(cmd,"DENY")==0) {
+                        // Arbitrary number of arguments: [from] host names
+                        if((hname=strtok(NULL,", \t\n")) && strcasecmp(hname,"FROM")==0)
+                          hname=strtok(NULL,", \t\n");
+                        if(hname) {           // host pattern(s) present
+                                struct sockaddr_in sockAdd;
+                                struct sockaddr_in* pSockAdd;
+                                char hostname[GATE_MAX_HOSTNAME_LENGTH];
+                                int status;
+                                char *ch;
+                                char *pIPInput;
 
-				pSockAdd = &sockAdd;
+                                pSockAdd = &sockAdd;
 
-				strncpy(inbufWithIPs,tempInbuf,hname - inbuf);
+                                strncpy(inbufWithIPs,tempInbuf,hname - inbuf);
 
-				pIPInput = inbufWithIPs + (hname - inbuf);
+                                pIPInput = inbufWithIPs + (hname - inbuf);
 
-				do {
-					/*convert all host names to ip addresses*/
-					status = aToIPAddr(hname,0,pSockAdd);
+                                do {
+                                        /*convert all host names to ip addresses*/
+                                        status = aToIPAddr(hname,0,pSockAdd);
 
-					if(status != -1)
-					{
-						ipAddrToDottedIP(pSockAdd,hostname,sizeof(hostname));
-						ch=strchr(hostname,':');
-						if(ch != NULL) hostname[ch-hostname]=0;
+                                        if(status != -1)
+                                        {
+                                                ipAddrToDottedIP(pSockAdd,hostname,sizeof(hostname));
+                                                ch=strchr(hostname,':');
+                                                if(ch != NULL) hostname[ch-hostname]=0;
 
                                                 strncpy(pIPInput,
                                                         hostname,
@@ -500,331 +505,331 @@ int gateAs::readPvList(const char* lfile)
                                                             - (pIPInput - inbufWithIPs));
                                                 *(pIPInput + strlen(hostname)) = ' ';
                                                 pIPInput = pIPInput + strlen(hostname) + 1;
-					}
-					else{
-						fprintf(stderr,"Error in PV list file (line %d): "
-			  				"cannot resolve host name >%s<\n",line,hname);
-					}
+                                        }
+                                        else{
+                                                fprintf(stderr,"Error in PV list file (line %d): "
+                                                        "cannot resolve host name >%s<\n",line,hname);
+                                        }
 
-				} while((hname=strtok(NULL,", \t\n")));
+                                } while((hname=strtok(NULL,", \t\n")));
 
-				*(pIPInput)='\0';
+                                *(pIPInput)='\0';
 
-			}else
-			{
-				strncpy(inbufWithIPs,tempInbuf,sizeof(inbufWithIPs)-1);
-				inbufWithIPs[sizeof(inbufWithIPs)-1]='\0';
-			}
+                        }else
+                        {
+                                strncpy(inbufWithIPs,tempInbuf,sizeof(inbufWithIPs)-1);
+                                inbufWithIPs[sizeof(inbufWithIPs)-1]='\0';
+                        }
 
-		}else
-		{
-			strncpy(inbufWithIPs,tempInbuf,sizeof(inbufWithIPs)-1);
-			inbufWithIPs[sizeof(inbufWithIPs)-1]='\0';
-		}
+                }else
+                {
+                        strncpy(inbufWithIPs,tempInbuf,sizeof(inbufWithIPs)-1);
+                        inbufWithIPs[sizeof(inbufWithIPs)-1]='\0';
+                }
 
-		pl=new gateAsLine(inbufWithIPs,line_list);
+                pl=new gateAsLine(inbufWithIPs,line_list);
 #else
-		if((ptr=strchr(inbuf,'#'))) *ptr='\0'; // Take care of comments
-		pl=new gateAsLine(inbuf,line_list);
+                if((ptr=strchr(inbuf,'#'))) *ptr='\0'; // Take care of comments
+                pl=new gateAsLine(inbuf,line_list);
 #endif
-		if(!(pattern=strtok(pl->buf," \t\n"))) continue;
+                if(!(pattern=strtok(pl->buf," \t\n"))) continue;
 
-		if(!(cmd=strtok(NULL," \t\n")))	{
-			fprintf(stderr,"Error in PV list file (line %d): "
-			  "missing command\n",line);
-			continue;
-		}
+                if(!(cmd=strtok(NULL," \t\n")))	{
+                        fprintf(stderr,"Error in PV list file (line %d): "
+                          "missing command\n",line);
+                        continue;
+                }
 
 
 #ifdef USE_DENYFROM
-		if(strcasecmp(cmd,"DENY")==0) {                          // DENY [FROM]
-			// Arbitrary number of arguments: [from] host names
-			if((hname=strtok(NULL,", \t\n")) && strcasecmp(hname,"FROM")==0)
-			  hname=strtok(NULL,", \t\n");
-			if(hname) {           // host pattern(s) present
-				do {
-					pe = new gateAsEntry(pattern);
-					if(pe->init(hname,deny_from_table,host_list,line)==aitFalse) {
-						delete pe;
-					} else {
-						denyFromListUsed=true;
-					}
-				} while((hname=strtok(NULL,", \t\n")));
-			} else {
-				// no host name specified
-				pe = new gateAsEntry(pattern);
-				if(pe->init(deny_list,line)==aitFalse) delete pe;
-			}
-			continue;
-		}
+                if(strcasecmp(cmd,"DENY")==0) {                          // DENY [FROM]
+                        // Arbitrary number of arguments: [from] host names
+                        if((hname=strtok(NULL,", \t\n")) && strcasecmp(hname,"FROM")==0)
+                          hname=strtok(NULL,", \t\n");
+                        if(hname) {           // host pattern(s) present
+                                do {
+                                        pe = new gateAsEntry(pattern);
+                                        if(pe->init(hname,deny_from_table,host_list,line)==aitFalse) {
+                                                delete pe;
+                                        } else {
+                                                denyFromListUsed=true;
+                                        }
+                                } while((hname=strtok(NULL,", \t\n")));
+                        } else {
+                                // no host name specified
+                                pe = new gateAsEntry(pattern);
+                                if(pe->init(deny_list,line)==aitFalse) delete pe;
+                        }
+                        continue;
+                }
 #else
-		if(strcasecmp(cmd,"DENY")==0) {                          // DENY [FROM]
-			// Arbitrary number of arguments: [from] host names
-			if((hname=strtok(NULL,", \t\n")) && strcasecmp(hname,"FROM")==0)
-			  hname=strtok(NULL,", \t\n");
-			if(hname) {           // host name(s) present
-				fprintf(stderr,"Error in PV list file (line %d): "
-				  "DENY FROM is not supported\n"
-				  "  Use EPICS_CAS_IGNORE_ADDR_LIST instead\n",
-				  line);
-			} else {
-				// no host name specified
-				pe = new gateAsEntry(pattern);
-				if(pe->init(deny_list,line)==aitFalse) delete pe;
-			}
-			continue;
-		}
+                if(strcasecmp(cmd,"DENY")==0) {                          // DENY [FROM]
+                        // Arbitrary number of arguments: [from] host names
+                        if((hname=strtok(NULL,", \t\n")) && strcasecmp(hname,"FROM")==0)
+                          hname=strtok(NULL,", \t\n");
+                        if(hname) {           // host name(s) present
+                                fprintf(stderr,"Error in PV list file (line %d): "
+                                  "DENY FROM is not supported\n"
+                                  "  Use EPICS_CAS_IGNORE_ADDR_LIST instead\n",
+                                  line);
+                        } else {
+                                // no host name specified
+                                pe = new gateAsEntry(pattern);
+                                if(pe->init(deny_list,line)==aitFalse) delete pe;
+                        }
+                        continue;
+                }
 #endif
 
-		if(strcasecmp(cmd,"ORDER")==0) {                               // ORDER
-			// Arguments: "allow, deny" or "deny, allow"
-			if(!(hname=strtok(NULL,", \t\n")) ||
-			  !(rname=strtok(NULL,", \t\n"))) {
-				fprintf(stderr,"Error in PV list file (line %d): "
-				  "missing argument to '%s' command\n",line,cmd);
-				continue;
-			}
-			if(strcasecmp(hname,"ALLOW")==0 &&
-			  strcasecmp(rname,"DENY")==0)	{
-				eval_order = GATE_ALLOW_FIRST;
-			} else if(strcasecmp(hname,"DENY")==0 &&
-			  strcasecmp(rname,"ALLOW")==0)	{
-				eval_order = GATE_DENY_FIRST;
-			} else {
-				fprintf(stderr,"Error in PV list file (line %d): "
-				  "invalid argument to '%s' command\n",line,cmd);
-			}
-			continue;
-		}
+                if(strcasecmp(cmd,"ORDER")==0) {                               // ORDER
+                        // Arguments: "allow, deny" or "deny, allow"
+                        if(!(hname=strtok(NULL,", \t\n")) ||
+                          !(rname=strtok(NULL,", \t\n"))) {
+                                fprintf(stderr,"Error in PV list file (line %d): "
+                                  "missing argument to '%s' command\n",line,cmd);
+                                continue;
+                        }
+                        if(strcasecmp(hname,"ALLOW")==0 &&
+                          strcasecmp(rname,"DENY")==0)	{
+                                eval_order = GATE_ALLOW_FIRST;
+                        } else if(strcasecmp(hname,"DENY")==0 &&
+                          strcasecmp(rname,"ALLOW")==0)	{
+                                eval_order = GATE_DENY_FIRST;
+                        } else {
+                                fprintf(stderr,"Error in PV list file (line %d): "
+                                  "invalid argument to '%s' command\n",line,cmd);
+                        }
+                        continue;
+                }
 
-		if(strcasecmp(cmd,"ALIAS")==0) {                     // ALIAS extra arg
-			// Additional (first) argument: real PV name
-			if(!(rname=strtok(NULL," \t\n"))) {
-				fprintf(stderr,"Error in PV list file (line %d): "
-				  "missing real name in ALIAS command\n",line);
-				continue;
-			}
-		}
+                if(strcasecmp(cmd,"ALIAS")==0) {                     // ALIAS extra arg
+                        // Additional (first) argument: real PV name
+                        if(!(rname=strtok(NULL," \t\n"))) {
+                                fprintf(stderr,"Error in PV list file (line %d): "
+                                  "missing real name in ALIAS command\n",line);
+                                continue;
+                        }
+                }
 
-		if((asg=strtok(NULL," \t\n"))) {                           // ASG / ASL
-			if((asl=strtok(NULL," \t\n")) &&
-			  (sscanf(asl,"%d",&lev)!=1)) lev=1;
-		} else {
-			asg=(char*)default_group;
-			lev=1;
-		}
+                if((asg=strtok(NULL," \t\n"))) {                           // ASG / ASL
+                        if((asl=strtok(NULL," \t\n")) &&
+                          (sscanf(asl,"%d",&lev)!=1)) lev=1;
+                } else {
+                        asg=(char*)default_group;
+                        lev=1;
+                }
 
-		if(strcasecmp(cmd,"ALLOW")==0   ||                           // ALLOW / ALIAS
-		  strcasecmp(cmd,"ALIAS")==0   ||
-		  strcasecmp(cmd,"PATTERN")==0 ||
-		  strcasecmp(cmd,"PV")==0) {
-			pe = new gateAsEntry(pattern,rname,asg,lev);
-			if(pe->init(allow_list,line)==aitFalse) delete pe;
-			continue;
-		} else {
-			// invalid
-			fprintf(stderr,"Error in PV list file (line %d): "
-			  "invalid command '%s'\n",line,cmd);
-		}
-	}
+                if(strcasecmp(cmd,"ALLOW")==0   ||                           // ALLOW / ALIAS
+                  strcasecmp(cmd,"ALIAS")==0   ||
+                  strcasecmp(cmd,"PATTERN")==0 ||
+                  strcasecmp(cmd,"PV")==0) {
+                        pe = new gateAsEntry(pattern,rname,asg,lev);
+                        if(pe->init(allow_list,line)==aitFalse) delete pe;
+                        continue;
+                } else {
+                        // invalid
+                        fprintf(stderr,"Error in PV list file (line %d): "
+                          "invalid command '%s'\n",line,cmd);
+                }
+        }
 
-	fclose(fd);
-	return 0;
+        fclose(fd);
+        return 0;
 }
 
 long gateAs::initialize(const char* afile)
 {
-	long rc=0;
+        long rc=0;
 
-	if(rules_installed==aitTrue) {
-		fprintf(stderr,"Access security rules already installed\n");
-		return -1;
-	}
+        if(rules_installed==aitTrue) {
+                fprintf(stderr,"Access security rules already installed\n");
+                return -1;
+        }
 
-	if(afile) {
-		errno=0;
-		rules_fd=fopen(afile,"r");
-		if(rules_fd == NULL) {
-			// Open failed
-			fprintf(stderr,"Failed to open security file: %s\n",afile);
-			fflush(stderr);
-			perror("Reason");
-			fflush(stderr);
-			fprintf(stderr,"Setting default security rules\n");
-			fflush(stderr);
-			use_default_rules=aitTrue;
-			rc=asInitialize(::readFunc);
-			if(rc) {
-				fprintf(stderr,"Failed to set default security rules\n");
-				fflush(stderr);
-			}
-		} else {
-			// Open succeeded
-			rc=asInitialize(::readFunc);
-			if(rc) fprintf(stderr,"Failed to read security file: %s\n",afile);
-			fclose(rules_fd);
-		}
-	} else {
-		// afile is NULL
-		use_default_rules=aitTrue;
-		rc=asInitialize(::readFunc);
-		if(rc) fprintf(stderr,"Failed to set default security rules\n");
-	}
+        if(afile) {
+                errno=0;
+                rules_fd=fopen(afile,"r");
+                if(rules_fd == NULL) {
+                        // Open failed
+                        fprintf(stderr,"Failed to open security file: %s\n",afile);
+                        fflush(stderr);
+                        perror("Reason");
+                        fflush(stderr);
+                        fprintf(stderr,"Setting default security rules\n");
+                        fflush(stderr);
+                        use_default_rules=aitTrue;
+                        rc=asInitialize(::readFunc);
+                        if(rc) {
+                                fprintf(stderr,"Failed to set default security rules\n");
+                                fflush(stderr);
+                        }
+                } else {
+                        // Open succeeded
+                        rc=asInitialize(::readFunc);
+                        if(rc) fprintf(stderr,"Failed to read security file: %s\n",afile);
+                        fclose(rules_fd);
+                }
+        } else {
+                // afile is NULL
+                use_default_rules=aitTrue;
+                rc=asInitialize(::readFunc);
+                if(rc) fprintf(stderr,"Failed to set default security rules\n");
+        }
 
-	if(rc==0) rules_installed=aitTrue;
-	return rc;
+        if(rc==0) rules_installed=aitTrue;
+        return rc;
 }
 
 long gateAs::reInitialize(const char* afile, const char* lfile)
 {
-	// Stop in INP PV clients
-	gateAsCaClear();
+        // Stop in INP PV clients
+        gateAsCaClear();
 
-	// Cleanup
+        // Cleanup
 #ifdef USE_DENYFROM
-	tsSLIter<gateAsHost> pi = host_list.firstIter();
+        tsSLIter<gateAsHost> pi = host_list.firstIter();
     gateAsList *l = NULL;
 
-	gateAsHost *pNode;
-	while(pi.pointer())	{
-		pNode=pi.pointer();
-		deny_from_table.remove(pNode->host,l);
-		clearAsList(*l);
-		pi++;
-	}
-	clearHostList(host_list);
+        gateAsHost *pNode;
+        while(pi.pointer())	{
+                pNode=pi.pointer();
+                deny_from_table.remove(pNode->host,l);
+                clearAsList(*l);
+                pi++;
+        }
+        clearHostList(host_list);
 #endif
-	clearAsList(deny_list);
-	clearAsList(allow_list);
-	clearAsList(line_list);
+        clearAsList(deny_list);
+        clearAsList(allow_list);
+        clearAsList(line_list);
 
-	// Reset defaults
-	default_group = "DEFAULT";
-	default_pattern = "*";
-	eval_order = GATE_ALLOW_FIRST;
-	rules_installed = aitFalse;
-	use_default_rules = aitFalse;
-	rules_fd = NULL;
+        // Reset defaults
+        default_group = "DEFAULT";
+        default_pattern = "*";
+        eval_order = GATE_ALLOW_FIRST;
+        rules_installed = aitFalse;
+        use_default_rules = aitFalse;
+        rules_fd = NULL;
 
-	// Reread the access file
-	if(afile) {
-		if(initialize(afile))
-		  fprintf(stderr,"Failed to install access security file %s\n",afile);
-	}
+        // Reread the access file
+        if(afile) {
+                if(initialize(afile))
+                  fprintf(stderr,"Failed to install access security file %s\n",afile);
+        }
 
-	// Restart INP PV clients
-	gateAsCa();
+        // Restart INP PV clients
+        gateAsCa();
 
-	// Reread the pvlist file (Will use defaults if lfile is NULL)
-	readPvList(lfile);
+        // Reread the pvlist file (Will use defaults if lfile is NULL)
+        readPvList(lfile);
 
-	return 0;
+        return 0;
 }
 
 int gateAs::readFunc(char* buf, size_t max)
 {
     size_t l, n;
-	static aitBool one_pass=aitFalse;
-	static char rbuf[150];
-	static char* rptr=NULL;
+        static aitBool one_pass=aitFalse;
+        static char rbuf[150];
+        static char* rptr=NULL;
 
-	if(rptr==NULL) {
-		rbuf[0]='\0';
-		rptr=rbuf;
+        if(rptr==NULL) {
+                rbuf[0]='\0';
+                rptr=rbuf;
 
-		if(use_default_rules==aitTrue) {
-			if(one_pass==aitFalse) {
-				strcpy(rbuf,"ASG(DEFAULT) { RULE(1,READ) }");
-				one_pass=aitTrue;
-			} else {
-				n=0;
-			}
-		} else if(fgets(rbuf,sizeof(rbuf),rules_fd)==NULL) {
-			n=0;
-		}
+                if(use_default_rules==aitTrue) {
+                        if(one_pass==aitFalse) {
+                                strcpy(rbuf,"ASG(DEFAULT) { RULE(1,READ) }");
+                                one_pass=aitTrue;
+                        } else {
+                                n=0;
+                        }
+                } else if(fgets(rbuf,sizeof(rbuf),rules_fd)==NULL) {
+                        n=0;
+                }
     }
 
-	l=strlen(rptr);
+        l=strlen(rptr);
     n = (l <= max) ? l : max;
-	if(n) {
-		memcpy(buf,rptr,n);
-		rptr+=n;
-	}
+        if(n) {
+                memcpy(buf,rptr,n);
+                rptr+=n;
+        }
 
-	if(rptr[0]=='\0')
-	  rptr=NULL;
+        if(rptr[0]=='\0')
+          rptr=NULL;
 
     return (int) n;
 }
 
 void gateAs::report(FILE* fd)
 {
-	time_t t;
-	time(&t);
+        time_t t;
+        time(&t);
 
-	fprintf(fd,"---------------------------------------------------------------------------\n"
-	  "Configuration Report: %s",ctime(&t));
-	fprintf(fd,"\n============================ Allowed PV Report ============================\n");
-	fprintf(fd," Pattern                        ASG             ASL Alias\n");
-	tsSLIter<gateAsEntry> pi1 = allow_list.firstIter();
-	gateAsEntry *pEntry1;
-	while(pi1.pointer()) {
-		pEntry1=pi1.pointer();
-		fprintf(fd," %-30s %-16s %d ",pEntry1->pattern,pEntry1->group,pEntry1->level);
-		if(pEntry1->alias) fprintf(fd," %s\n",pEntry1->alias);
-		else fprintf(fd,"\n");
-		pi1++;
-	}
+        fprintf(fd,"---------------------------------------------------------------------------\n"
+          "Configuration Report: %s",ctime(&t));
+        fprintf(fd,"\n============================ Allowed PV Report ============================\n");
+        fprintf(fd," Pattern                        ASG             ASL Alias\n");
+        tsSLIter<gateAsEntry> pi1 = allow_list.firstIter();
+        gateAsEntry *pEntry1;
+        while(pi1.pointer()) {
+                pEntry1=pi1.pointer();
+                fprintf(fd," %-30s %-16s %d ",pEntry1->pattern,pEntry1->group,pEntry1->level);
+                if(pEntry1->alias) fprintf(fd," %s\n",pEntry1->alias);
+                else fprintf(fd,"\n");
+                pi1++;
+        }
 
-	fprintf(fd,"\n============================ Denied PV Report  ============================\n");
-	tsSLIter<gateAsEntry> pi2 = deny_list.firstIter();
-	gateAsEntry *pEntry2;
-	if(pi2.pointer()) {
-		fprintf(fd,"\n==== Denied from ALL Hosts:\n");
-		while(pi2.pointer()) {
-			pEntry2=pi2.pointer();
-			fprintf(fd," %s\n",pEntry2->pattern);
-			pi2++;
-		}
-	}
+        fprintf(fd,"\n============================ Denied PV Report  ============================\n");
+        tsSLIter<gateAsEntry> pi2 = deny_list.firstIter();
+        gateAsEntry *pEntry2;
+        if(pi2.pointer()) {
+                fprintf(fd,"\n==== Denied from ALL Hosts:\n");
+                while(pi2.pointer()) {
+                        pEntry2=pi2.pointer();
+                        fprintf(fd," %s\n",pEntry2->pattern);
+                        pi2++;
+                }
+        }
 
 #ifdef USE_DENYFROM
-	tsSLIter<gateAsHost> pi3 = host_list.firstIter();
-	gateAsHost *pEntry3;
-	while(pi3.pointer()) {
-		pEntry3=pi3.pointer();
-		fprintf(fd,"\n==== Denied from Host %s:\n",pEntry3->host);
-		gateAsList* pl=NULL;
-		if(deny_from_table.find(pEntry3->host,pl)==0) {
-			tsSLIter<gateAsEntry> pi4 = pl->firstIter();
-			gateAsEntry *pEntry4;
-			while(pi4.pointer()) {
-				pEntry4=pi4.pointer();
-				fprintf(fd," %s\n",pEntry4->pattern);
-				pi4++;
-			}
-		}
-		pi3++;
-	}
+        tsSLIter<gateAsHost> pi3 = host_list.firstIter();
+        gateAsHost *pEntry3;
+        while(pi3.pointer()) {
+                pEntry3=pi3.pointer();
+                fprintf(fd,"\n==== Denied from Host %s:\n",pEntry3->host);
+                gateAsList* pl=NULL;
+                if(deny_from_table.find(pEntry3->host,pl)==0) {
+                        tsSLIter<gateAsEntry> pi4 = pl->firstIter();
+                        gateAsEntry *pEntry4;
+                        while(pi4.pointer()) {
+                                pEntry4=pi4.pointer();
+                                fprintf(fd," %s\n",pEntry4->pattern);
+                                pi4++;
+                        }
+                }
+                pi3++;
+        }
 #endif
 
-	if(eval_order==GATE_DENY_FIRST)
-	  fprintf(fd,"\nEvaluation order: deny, allow\n");
-	else
-	  fprintf(fd,"\nEvaluation order: allow, deny\n");
+        if(eval_order==GATE_DENY_FIRST)
+          fprintf(fd,"\nEvaluation order: deny, allow\n");
+        else
+          fprintf(fd,"\nEvaluation order: allow, deny\n");
 
-	if(rules_installed==aitTrue) fprintf(fd,"Access Rules are installed.\n");
-	if(use_default_rules==aitTrue) fprintf(fd,"Using default access rules.\n");
-	
+        if(rules_installed==aitTrue) fprintf(fd,"Access Rules are installed.\n");
+        if(use_default_rules==aitTrue) fprintf(fd,"Using default access rules.\n");
+
 #if (EPICS_VERSION > 3 || (EPICS_REVISION == 14 && EPICS_MODIFICATION >= 6) || EPICS_REVISION > 14)
-	// Dumping to a file pointer became available sometime during 3.14.5.
-	fprintf(fd,"\n============================ Access Security Dump =========================\n");
-	asDumpFP(fd,NULL,NULL,TRUE);
+        // Dumping to a file pointer became available sometime during 3.14.5.
+        fprintf(fd,"\n============================ Access Security Dump =========================\n");
+        asDumpFP(fd,NULL,NULL,TRUE);
 #else
-	// KE: Could use asDump, but it would go to stdout, probably
-	// gateway.log, and not be in gateway.report
+        // KE: Could use asDump, but it would go to stdout, probably
+        // gateway.log, and not be in gateway.report
 #endif
-	fprintf(fd,"-----------------------------------------------------------------------------\n");
+        fprintf(fd,"-----------------------------------------------------------------------------\n");
 }
 
 /* **************************** Emacs Editing Sequences ***************** */

--- a/src/gateAs.h
+++ b/src/gateAs.h
@@ -45,8 +45,9 @@ extern "C" {
 #include "tsHash.h"
 #include "aitTypes.h"
 
-#ifdef USE_PCRE
-#include <pcre.h>
+#ifdef USE_PCRE2
+#define PCRE2_CODE_UNIT_WIDTH 8
+#include <pcre2.h>
 #else
 
 extern "C" {
@@ -65,7 +66,7 @@ extern "C" {
 #endif
 }
 
-#endif /* USE_PCRE */
+#endif /* USE_PCRE2 */
 /*
  * Standard FALSE and TRUE macros
  */
@@ -121,18 +122,19 @@ public:
 #endif
 	long removeMember(void);
 
-	void getRealName(const char* pv, char* real, int len);
+        void getRealName(const char* pv, char* real, size_t len);
 
-	const char* pattern;
+        const char* pattern;
 	const char* alias;
 	const char* group;
 	int level;
 	ASMEMBERPVT asmemberpvt;
-#ifdef USE_PCRE
-	pcre* pat_buff;
+#ifdef USE_PCRE2
+	pcre2_code* pat_buff;
+	pcre2_match_data* match_data;
 	int substrings;
-	int ovecsize;
-	int *ovector;
+	size_t ovecsize;
+	size_t *ovector;
 #else
 	char pat_valid;
 	struct re_pattern_buffer pat_buff;

--- a/testTop/pyTestsApp/Makefile
+++ b/testTop/pyTestsApp/Makefile
@@ -14,8 +14,8 @@ TAPFILES = testresults.tap
 TEST_FILES += test.db
 TEST_FILES += access.txt
 
-# Which pvlist.txt file depends on USE_PCRE
-USE_PCRE ?= NO
+# Which pvlist.txt file depends on USE_PCRE2
+USE_PCRE2 ?= NO
 PVLIST_YES = pvlist_pcre.txt
 PVLIST_NO = pvlist_bre.txt
 
@@ -64,8 +64,8 @@ testmodule: $(TEST_SCRIPTS)
 	$(ECHO) "Copying test module $(TEST_MODULE)"
 	@$(CP) -r ../$(TEST_MODULE) ./
 
-pvlist.txt: ../$(PVLIST_$(USE_PCRE))
-	$(ECHO) "Copying $< to $@ (USE_PCRE: $(USE_PCRE))"
+pvlist.txt: ../$(PVLIST_$(USE_PCRE2))
+	$(ECHO) "Copying $< to $@ (USE_PCRE2: $(USE_PCRE2))"
 	@$(CP) $< $@
 
 .PHONY: build runtests testmodule testfiles clean

--- a/testTop/pyTestsApp/gateway_tests/config.py
+++ b/testTop/pyTestsApp/gateway_tests/config.py
@@ -33,7 +33,7 @@ default_gateway_port = 62783
 default_putlog_port = 45635
 default_access = os.environ.get("GATEWAY_ACCESS", str(WORKING_DIRECTORY / "access.txt"))
 
-use_pcre = _boolean_option(os.environ.get("USE_PCRE", ""))
+use_pcre = _boolean_option(os.environ.get("USE_PCRE2", ""))
 default_pvlist = os.environ.get("GATEWAY_PVLIST", str(WORKING_DIRECTORY / "pvlist.txt"))
 test_ioc_db = os.environ.get("TEST_DB", str(WORKING_DIRECTORY / "test.db"))
 

--- a/testTop/pyTestsApp/pvlist_pcre.txt
+++ b/testTop/pyTestsApp/pvlist_pcre.txt
@@ -1,4 +1,4 @@
-# gwlist file for Gateway tests - using PCRE
+# gwlist file for Gateway tests - using PCRE2
 #
 # Convert gateway: prefix to ioc: prefix on IOC side
 # Do NOT serve the IOC channels under their original name


### PR DESCRIPTION
Migrate from the unmaintained PCRE library to PCRE2
Key changes:
- Replace USE_PCRE with USE_PCRE2 in build configuration
- Link against libpcre2-8
- Update src/gateAs.cc and src/gateAs.h to use PCRE2 API
- Replace manual ovector management with pcre2_match_data
- Update documentation and test suite to reflect the change
- Remove legacy PCRE3 specific logic for Windows

Co-authored-by: google-labs-jules[bot]
Co-authored-by: Dirk Zimoch

(closes #54; closes #66)